### PR TITLE
Fix for when you authenticate against the portal first and then go to kits for an existing user

### DIFF
--- a/wp-content/plugins/authorizer/authorizer.php
+++ b/wp-content/plugins/authorizer/authorizer.php
@@ -1130,8 +1130,14 @@ if ( ! class_exists( 'WP_Plugin_Authorizer' ) ) {
 			// used if we can't discover the email address from CAS attributes.
 			$domain_guess = preg_match( '/[^.]*\.[^.]*$/', $auth_settings['cas_host'], $matches ) === 1 ? $matches[0] : '';
 
-			// Get username that successfully authenticated against the external service (CAS).
-			$externally_authenticated_email = strtolower( $username ) . '@' . $domain_guess;
+
+                        // BV edit: don't add the domain guess if the username is an email, e.g. it contains and @ symbol
+                        // It ends up creating two users for the same username depending on how you authenticate which then
+                        // results in unlimitied redirects when the two separate code paths get the wrong user
+
+                        // Get username that successfully authenticated against the external service (CAS).
+                       //$externally_authenticated_email = strtolower( $username ) . '@' . $domain_guess;
+                       $externally_authenticated_email = (strpos($username, '@') !== false) ? strtolower( $username ) : strtolower( $username ) . '@' . $domain_guess;
 
 			// Retrieve the user attributes (e.g., email address, first name, last name) from the CAS server.
 			$cas_attributes = phpCAS::getAttributes();


### PR DESCRIPTION
Was getting 'Too many redirects' b/c user wasn't found