### PR TITLE
Hide facilitator if LC

### DIFF
--- a/wp-content/themes/bzLLKit/single-kit.php
+++ b/wp-content/themes/bzLLKit/single-kit.php
@@ -281,7 +281,7 @@ get_header(); ?>
 							<span class="minutes"><?php echo $activity_post->duration .'&nbsp;'. __('Minutes', 'bz'); ?></span>
 							<?php if ($activity_facilitator) { ?>
 								<span class="facilitator facilitator-<?php echo $activity_facilitator;?>">
-									<?php echo __('Facilitated by ', 'bz') . $bz_facilitators[$activity_facilitator]; // get user-facing title by key. $bz_facilitators is defined in functions.php ?>
+									<?php if ('coach' != $activity_facilitator) echo __('Facilitated by ', 'bz') . $bz_facilitators[$activity_facilitator]; // get user-facing title by key. $bz_facilitators is defined in functions.php ?>
 								</span>
 							<?php } // end if facilitator ?>
 						</div>						


### PR DESCRIPTION
Small fix to make sure we don't show "Facilitated by Coach" (since it's the default). This would only have happened if we assigned a different facilitator and then decided to assign back to the coach.