### PR TITLE
Set coaches as the default facilitator.

### DIFF
--- a/wp-content/themes/bzLLKit/functions.php
+++ b/wp-content/themes/bzLLKit/functions.php
@@ -588,6 +588,7 @@ function bz_meta_boxes( $meta_boxes ) {
 				'name' => __( 'Who is facilitating?', 'bz' ),
 				'type' => 'radio',
 				'options' => $bz_facilitators,
+				'std' => 'coach',
 			),
 		),
 	);

--- a/wp-content/themes/bzLLKit/single-kit.php
+++ b/wp-content/themes/bzLLKit/single-kit.php
@@ -306,6 +306,10 @@ get_header(); ?>
 								<span class="facilitator facilitator-<?php echo $activity_facilitator;?>">
 									<?php echo __('Facilitated by ', 'bz') . $bz_facilitators[$activity_facilitator]; // get user-facing title by key. $bz_facilitators is defined in functions.php ?>
 								</span>
+							<?php } else { ?>
+								<span class="facilitator facilitator-coach">
+									<?php echo 'Facilitated by Coach'; ?>
+								</span>
 							<?php } // end if facilitator ?>
 						</div>
 						<span class="activity-title"><?php echo $activity_post->post_title;?></span>


### PR DESCRIPTION
Hi Brian, I'm sorry to make you do another one :( I realized that a lot of our activities have no facilitator set whatsoever which is confusing. 

Setting a default meta box value for NEW activities via 'std'. In addition, in lieu of bulk updating every activity, I am visually indicating coaches as the default on the front-end when facilitator is empty.