### PR TITLE
Remove reason column description

### DIFF
--- a/attendance.php
+++ b/attendance.php
@@ -729,7 +729,7 @@ requireLogin();
 <title>Attendance Tracker</title>
 <style>
 	.main-attendance-view tr th:nth-child(4), .main-attendance-view tr td:nth-child(4) {
-		background-color: rgba(226,226,226, 0.4);
+		background-color: rgba(226,226,226, 0.3);
 	}
 	.main-attendance-view tr th {
 		padding-top: 15px;
@@ -896,14 +896,10 @@ requireLogin();
 		font-size:90%;
 	}
 
-	tr.reason-description {
+	tr.reason-description, 	tr.reason-description td {
 		background-color:white;
 		color: #999;
 		font-style: italic;
-	}
-
-	tr.reason-description td:nth-child(4) {
-		background-color:white;
 	}
 
 	input[name=reason]:not(:focus) {

--- a/attendance.php
+++ b/attendance.php
@@ -896,7 +896,7 @@ requireLogin();
 		font-size:90%;
 	}
 
-	tr.reason-description, 	tr.reason-description td {
+	tr.reason-description, 	tr.reason-description td, tr.reason-description:last-child td, .main-attendance-view tr.reason-description td:nth-child(4) {
 		background-color:white;
 		color: #999;
 		font-style: italic;

--- a/attendance.php
+++ b/attendance.php
@@ -896,12 +896,6 @@ requireLogin();
 		font-size:90%;
 	}
 
-	tr.reason-description, 	tr.reason-description td, tr.reason-description:last-child td, .main-attendance-view tr.reason-description td:nth-child(4) {
-		background-color:white;
-		color: #999;
-		font-style: italic;
-	}
-
 	input[name=reason]:not(:focus) {
 		background: transparent;
 		background-repeat: no-repeat;
@@ -1337,7 +1331,6 @@ requireLogin();
 						}
 						echo "</tr>";
 					}
-					echo "<tr class='reason-description'><td></td><td></td><td></td><td><small>Only use this field if a student reached out to you before missing or being late to a class.</small></td></tr>";
 					echo "</tbody>";
 					echo "</table>";
 


### PR DESCRIPTION
Removed "Only use this field if a student reached out to you before missing or being late to a class." at the bottom of attendance right column and associated styling.