### PR TITLE
Adds BravenX Pilot course ID to Kits

### DIFF
--- a/courses.php
+++ b/courses.php
@@ -4,4 +4,5 @@
 		"run" => 73,
 		"nlu" => 62,
 		"schwab" => 67,
+		"bravenx-pilot" => 81,
 	);


### PR DESCRIPTION
**Description**:
Roster for BravenX kits were not being pulled properly because the course name and ID were not added into the `courses.php`. 

**Summary**:
- Adds BravenX course ID to `courses.php`
