### PR TITLE
A Docker development environment that works with the other apps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+docker-compose.yml
+uploads.ini

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,8 @@
+# For files generated at runtime or with sensitive information that shouldn't
+# be built into the actual container image, ignore them here. Note that for mounted
+# volumes, at runtime these have no impact and will end up in the container. This is
+# only for buildtime files to be ignored so we can have a clean docker image.
 docker-compose.yml
 uploads.ini
+.htaccess
+wp-config.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM php:7.1-apache
+# This matches the staging and prod env.
+FROM php:7.0.8-apache
 
 # Required for Docker heroku.yml builds to change it..
 # See: https://devcenter.heroku.com/articles/build-docker-images-heroku-yml#setting-build-time-environment-variables
@@ -114,7 +115,13 @@ RUN { \
     echo "xdebug.remote_autostart=off"; \
 	} > /usr/local/etc/php/conf.d/xdebug.ini
 
-  
+# This is set by default on the Ubuntu DigitalOcean install which was letting the
+# Authorizor plugin work properly with a bug it has. Without this on, I ran into this issue:
+# https://wordpress.org/support/topic/warning-cannot-modify-header-information-headers-already-sent-18/
+RUN { \
+		echo 'output_buffering=4096'; \
+	} > /usr/local/etc/php/conf.d/php.ini
+
 ENV WORDPRESS_VERSION 5.2.3
 ENV WORDPRESS_SHA1 5efd37148788f3b14b295b2a9bf48a1a467aa303
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,125 @@
+FROM php:7.1-apache
+
+# persistent dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+# install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libjpeg-dev \
+		libmagickwand-dev \
+		libpng-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install -j "$(nproc)" \
+		bcmath \
+		exif \
+		gd \
+		mysqli \
+		opcache \
+		zip \
+	; \
+	pecl install imagick-3.4.4; \
+	docker-php-ext-enable imagick; \
+
+# Install XDebug for local debugging
+	pecl install xdebug-2.6.0; \ 
+    docker-php-ext-enable xdebug; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+# https://wordpress.org/support/article/editing-wp-config-php/#configure-error-logging
+RUN { \
+# https://www.php.net/manual/en/errorfunc.constants.php
+# https://github.com/docker-library/wordpress/issues/420#issuecomment-517839670
+		echo 'error_reporting = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_RECOVERABLE_ERROR'; \
+		echo 'display_errors = Off'; \
+		echo 'display_startup_errors = Off'; \
+		echo 'log_errors = On'; \
+		echo 'error_log = /dev/stderr'; \
+		echo 'log_errors_max_len = 1024'; \
+		echo 'ignore_repeated_errors = On'; \
+		echo 'ignore_repeated_source = Off'; \
+		echo 'html_errors = Off'; \
+	} > /usr/local/etc/php/conf.d/error-logging.ini
+
+RUN set -eux; \
+	a2enmod rewrite expires; \
+	\
+# https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html
+	a2enmod remoteip; \
+	{ \
+		echo 'RemoteIPHeader X-Forwarded-For'; \
+# these IP ranges are reserved for "private" use and should thus *usually* be safe inside Docker
+		echo 'RemoteIPTrustedProxy 10.0.0.0/8'; \
+		echo 'RemoteIPTrustedProxy 172.16.0.0/12'; \
+		echo 'RemoteIPTrustedProxy 192.168.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 169.254.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 127.0.0.0/8'; \
+	} > /etc/apache2/conf-available/remoteip.conf; \
+	a2enconf remoteip; \
+# https://github.com/docker-library/wordpress/issues/383#issuecomment-507886512
+# (replace all instances of "%h" with "%a" in LogFormat)
+	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
+
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+RUN { \
+	echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)"; \
+    echo "xdebug.remote_enable=on"; \
+    echo "xdebug.remote_autostart=off"; \
+	} > /usr/local/etc/php/conf.d/xdebug.ini
+
+  
+ENV WORDPRESS_VERSION 5.2.3
+ENV WORDPRESS_SHA1 5efd37148788f3b14b295b2a9bf48a1a467aa303
+
+RUN set -ex; \
+	curl -o wordpress.tar.gz -fSL "https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz"; \
+	echo "$WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c -; \
+# upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
+	tar -xzf wordpress.tar.gz -C /usr/src/; \
+	rm wordpress.tar.gz; \
+	chown -R www-data:www-data /usr/src/wordpress
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+CMD ["apache2-foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM php:7.0.8-apache
 # Required for Docker heroku.yml builds to change it..
 # See: https://devcenter.heroku.com/articles/build-docker-images-heroku-yml#setting-build-time-environment-variables
 ARG SERVERNAME=localhost
+ARG SERVERPORT=80
 
 # persistent dependencies
 RUN set -eux; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN set -ex; \
 		gd \
 		mysqli \
 		opcache \
+    pdo \
+    pdo_mysql \
 		zip \
 	; \
 	pecl install imagick-3.4.4; \
@@ -130,6 +132,9 @@ COPY docker-compose/config/apache2.conf.template /etc/apache2/sites-available/00
 
 # New versions of vim enter visual mode when you use the mouse to highlight things (e.g. to copy / paste). Disable that.
 RUN echo "set mouse-=a" >> ~/.vimrc
+
+# BTODO: setup the cronjob to populate the attendance data for the attendance API. See "crontab -u www-data -e"
+# in the Kits Production Setup doc.
 
 # If I change this to bash as the default, does that impact anything? Do I need to run apache2-foreground 
 # from docker_compose_run.sh since thats the entrypoint now for docker-compose.yml? 

--- a/attendance.php
+++ b/attendance.php
@@ -421,6 +421,10 @@ requireLogin();
 		$ch = curl_init();
     $baseUrl = getPortalBaseUrl();
 		$url = $baseUrl . '/bz/courses_for_email?email='.(urlencode($email)). '&access_token=' . urlencode($WP_CONFIG["CANVAS_TOKEN"]);
+
+    // Uncomment to log above call to browswer console so you can login to server and try to curl it to see what you get.
+    //echo("<script>console.log('Attendance tracker getting course ID for user by calling: " . $url . "');</script>");
+
 		// Change stagingportal to portal here when going live!
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);

--- a/attendance.php
+++ b/attendance.php
@@ -325,6 +325,7 @@ function bz_current_full_url() {
 function sso() {
 	global $WP_CONFIG;
 
+
 	if(isset($_SESSION["sso_service"]) && isset($_SESSION["coming_from"]) && isset($_GET["ticket"])) {
 		// validate ticket from the SSO server
 
@@ -334,7 +335,8 @@ function sso() {
 		unset($_SESSION["sso_service"]);
 		unset($_SESSION["coming_from"]);
 
-		$content = file_get_contents("https://{$WP_CONFIG["BRAVEN_SSO_DOMAIN"]}/serviceValidate?ticket=".urlencode($ticket)."&service=".urlencode($service));
+    $baseUrl = getSSOBaseUrl();
+		$content = file_get_contents("{$baseUrl}/serviceValidate?ticket=".urlencode($ticket)."&service=".urlencode($service));
 
 		$xml = new DOMDocument();
 		$xml->loadXML($content);
@@ -349,7 +351,8 @@ function sso() {
 	} else if(isset($_SESSION["coming_from"]) && !isset($_SESSION["sso_service"])) {
 		$ssoService = bz_current_full_url() . "&dosso";
 		$_SESSION["sso_service"] = $ssoService;
-		header("Location: https://{$WP_CONFIG["BRAVEN_SSO_DOMAIN"]}/login?service=" . urlencode($ssoService));
+    $baseUrl = getSSOBaseUrl();
+		header("Location: {$baseUrl}/login?service=" . urlencode($ssoService));
 		exit;
 	} // otherwise it is just an api thing for other uses
 }
@@ -416,7 +419,8 @@ requireLogin();
 		global $braven_courses;
 
 		$ch = curl_init();
-		$url = 'https://'.$WP_CONFIG["BRAVEN_PORTAL_DOMAIN"].'/bz/courses_for_email?email='.(urlencode($email)). '&access_token=' . urlencode($WP_CONFIG["CANVAS_TOKEN"]);
+    $baseUrl = getPortalBaseUrl();
+		$url = $baseUrl . '/bz/courses_for_email?email='.(urlencode($email)). '&access_token=' . urlencode($WP_CONFIG["CANVAS_TOKEN"]);
 		// Change stagingportal to portal here when going live!
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);

--- a/attendance_api.php
+++ b/attendance_api.php
@@ -41,7 +41,8 @@ if(php_sapi_name() == 'cli') {
 		global $WP_CONFIG;
 
 		$ch = curl_init();
-		$url = 'https://'.$WP_CONFIG["BRAVEN_PORTAL_DOMAIN"].'/api/v1/courses/'.$course_id.'/custom_gradebook_columns/'.$column_number.'/data/'.$uid;
+    $baseUrl = getPortalBaseUrl();
+    $url = $baseUrl . '/api/v1/courses/'.$course_id.'/custom_gradebook_columns/'.$column_number.'/data/'.$uid;
 
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT");
 
@@ -59,7 +60,8 @@ if(php_sapi_name() == 'cli') {
 		global $WP_CONFIG;
 
 		$ch = curl_init();
-		$url = 'https://'.$WP_CONFIG["BRAVEN_PORTAL_DOMAIN"].'/api/v1/courses/'.$course_id.'/custom_gradebook_columns?access_token='.urlencode($WP_CONFIG["CANVAS_TOKEN"]);
+    $baseUrl = getPortalBaseUrl();
+    $url = $baseUrl . '/api/v1/courses/'.$course_id.'/custom_gradebook_columns?access_token='.urlencode($WP_CONFIG["CANVAS_TOKEN"]);
 
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
@@ -75,7 +77,8 @@ if(php_sapi_name() == 'cli') {
 		// not there, create a column
 
 		$ch = curl_init();
-		$url = 'https://'.$WP_CONFIG["BRAVEN_PORTAL_DOMAIN"].'/api/v1/courses/'.$course_id.'/custom_gradebook_columns';
+    $baseUrl = getPortalBaseUrl();
+    $url = $baseUrl . '/api/v1/courses/'.$course_id.'/custom_gradebook_columns';
 
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_POST, 1);

--- a/attendance_shared.php
+++ b/attendance_shared.php
@@ -120,18 +120,20 @@ function populate_times_from_canvas($course_id) {
 }
 
 function getProtocol(){
-   $protocol = "http";
+  $protocol = "http";
   if(isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on")
     $protocol .= "s";
-  return $protocol .= "//";
+  return $protocol .= "://";
 }
 
 function getPortalBaseUrl() {
+  global $WP_CONFIG;
   $protocol = getProtocol();
 	return $protocol . $WP_CONFIG["BRAVEN_PORTAL_DOMAIN"];
 }
 
 function getSSOBaseUrl() {
+  global $WP_CONFIG;
   $protocol = getProtocol();
 	return $protocol . $WP_CONFIG["BRAVEN_SSO_DOMAIN"];
 }

--- a/attendance_shared.php
+++ b/attendance_shared.php
@@ -50,7 +50,8 @@ function get_canvas_events($course_id, $start_date, $end_date) {
 		$additional .= "&end_date=".urlencode($end_date);
 
 	$ch = curl_init();
-	$url = 'https://'.$WP_CONFIG["BRAVEN_PORTAL_DOMAIN"].'/api/v1/calendar_events?per_page=500&context_codes[]=course_'.(urlencode($course_id)). '&access_token=' . urlencode($WP_CONFIG["CANVAS_TOKEN"]) . $additional;
+  $baseUrl = getPortalBaseUrl();
+  $url = $baseUrl . '/api/v1/calendar_events?per_page=500&context_codes[]=course_'.(urlencode($course_id)). '&access_token=' . urlencode($WP_CONFIG["CANVAS_TOKEN"]) . $additional;
 	curl_setopt($ch, CURLOPT_URL, $url);
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 	$answer = curl_exec($ch);
@@ -118,6 +119,23 @@ function populate_times_from_canvas($course_id) {
 	}
 }
 
+function getProtocol(){
+   $protocol = "http";
+  if(isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on")
+    $protocol .= "s";
+  return $protocol .= "//";
+}
+
+function getPortalBaseUrl() {
+  $protocol = getProtocol();
+	return $protocol . $WP_CONFIG["BRAVEN_PORTAL_DOMAIN"];
+}
+
+function getSSOBaseUrl() {
+  $protocol = getProtocol();
+	return $protocol . $WP_CONFIG["BRAVEN_SSO_DOMAIN"];
+}
+
 function isTa($user_email, $cohort_info) {
 	return in_array(strtolower($user_email), $cohort_info["tas"]);
 }
@@ -129,12 +147,16 @@ function get_cohorts_info($course_id) {
 		return $_SESSION["cohort_course_info_$course_id"];
 
 	$ch = curl_init();
-	$url = 'https://'.$WP_CONFIG["BRAVEN_PORTAL_DOMAIN"].'/bz/course_cohort_information?course_ids[]='.((int) $course_id). '&access_token=' . urlencode($WP_CONFIG["CANVAS_TOKEN"]);
+  $baseUrl = getPortalBaseUrl();
+	$url = $baseUrl . '/bz/course_cohort_information?course_ids[]='.((int) $course_id). '&access_token=' . urlencode($WP_CONFIG["CANVAS_TOKEN"]);
+
+  //echo("<script>console.log('PHP: calling: " . $url . "');</script>");
 
 	curl_setopt($ch, CURLOPT_URL, $url);
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 	$answer = curl_exec($ch);
 	curl_close($ch);
+
 
 	// trim off any cross-site get padding, if present,
 	// keeping just the json object

--- a/attendance_shared.php
+++ b/attendance_shared.php
@@ -152,7 +152,9 @@ function get_cohorts_info($course_id) {
   $baseUrl = getPortalBaseUrl();
 	$url = $baseUrl . '/bz/course_cohort_information?course_ids[]='.((int) $course_id). '&access_token=' . urlencode($WP_CONFIG["CANVAS_TOKEN"]);
 
-  //echo("<script>console.log('PHP: calling: " . $url . "');</script>");
+  // Uncomment to log above call to browswer console so you can login to server and try to curl it to see what you get.
+  // Note: curl has to be run like: curl --globoff -vvv "http://canvasweb:3000/bz/course_cohort_information?course_ids[]=71&access_token=<yourtoken>"
+  echo("<script>console.log('Attendance tracker calling the following to get attendance cohort info from Canvas: " . $url . "');</script>");
 
 	curl_setopt($ch, CURLOPT_URL, $url);
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,9 +40,9 @@ services:
       WORDPRESS_FORCE_SSL_ADMIN: 0
       ATTENDANCE_API_KEY: TODO
       DB_ATTENDANCE_NAME: braven_attendance
-      CANVAS_TOKEN: TODO
-      BRAVEN_SSO_DOMAIN: ssoweb
-      BRAVEN_PORTAL_DOMAIN: canvasweb
+      CANVAS_TOKEN: fG5BLbfZCiheKv6LJO13t1opFuTseKNAY6no6b7meHicN8UWsYAjaPU5TQFyB1TP
+      BRAVEN_SSO_DOMAIN: ssoweb:3002
+      BRAVEN_PORTAL_DOMAIN: canvasweb:3000
     working_dir: /var/www/html
     volumes:
       - .:/var/www/html/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,16 @@ services:
       WORDPRESS_DEBUG: 1
       WORDPRESS_TABLE_PREFIX: bz_
       WORDPRESS_FORCE_SSL_ADMIN: 0
-      ATTENDANCE_API_KEY: TODO
       DB_ATTENDANCE_NAME: braven_attendance
+      # The other value is "sms", but be careful. Then actual text messages would go out to remind LCs to take attendance!
+      ATTENDANCE_TRACKER_NOTIFY_METHOD: echo
+      # This is if a web app wants to call in to update the attendance in the Canvas gradebook. I think
+      # maybe this was called from the Content Editor?!? Either way, the way this functionality is currently
+      # working is that a cronjob is setup on staging and prod to run the attendance_api.php file occasionally
+      # and push attendance data to Canvas.
+      # In the dev env, we prob want a script or a task to manually force it to happen if we want to test/develop
+      # that feature.
+      ATTENDANCE_API_KEY: devattendanceapikey
       CANVAS_TOKEN: fG5BLbfZCiheKv6LJO13t1opFuTseKNAY6no6b7meHicN8UWsYAjaPU5TQFyB1TP
       BRAVEN_SSO_DOMAIN: ssoweb:3002
       BRAVEN_PORTAL_DOMAIN: canvasweb:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     #restart: always
     environment:
       MYSQL_ROOT_PASSWORD: pass
+      # Note that the mysql image automatically creates the database and user using the ENV vars below.
+      # See: https://hub.docker.com/_/mysql
       MYSQL_DATABASE: wordpress
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress
@@ -27,12 +29,12 @@ services:
     # I kind of want to see when it goes down and solve it rather than always just restarting it.
     #restart: always
     environment:
-      # TODO: create attendance database on here
       SERVERNAME: kitsweb
       WORDPRESS_DB_HOST: kitsdb:3306
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
+      MYSQL_ROOT_PASSWORD: pass
       WORDPRESS_DEBUG: 1
       WORDPRESS_TABLE_PREFIX: bz_
       WORDPRESS_FORCE_SSL_ADMIN: 0
@@ -44,7 +46,6 @@ services:
     working_dir: /var/www/html
     volumes:
       - .:/var/www/html/
-      - ./uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
     networks:
       - bravendev
       

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.5'
+
+services:
+  wordpress-db:
+    image: mysql:5.7
+    volumes:
+      - db_data:/var/lib/mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: pass
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+    networks:
+      - bravendev
+
+  wordpress:
+    build:
+        context: .
+    depends_on:
+      - wordpress-db
+    ports:
+      - "8000:80"
+    restart: always
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DEBUG: 1
+    working_dir: /var/www/html
+    volumes:
+      - .:/var/www/html/
+      - ./uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
+    networks:
+      - bravendev
+      
+# Note all Braven web app docker dev envs use this same network so they can talk to each other.
+# E.g. the hostname joinweb will resolve inside the ssoweb container if they are on the same docker network.
+networks:
+  bravendev:
+    name: braven_dev_network
+
+volumes:
+  db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,11 +25,12 @@ services:
     depends_on:
       - kitsdb
     ports:
-      - "3005:80"
+      - "3005:3005"
     # I kind of want to see when it goes down and solve it rather than always just restarting it.
     #restart: always
     environment:
       SERVERNAME: kitsweb
+      SERVERPORT: 3005
       WORDPRESS_DB_HOST: kitsdb:3306
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_DB_USER: wordpress
@@ -48,7 +49,7 @@ services:
       # In the dev env, we prob want a script or a task to manually force it to happen if we want to test/develop
       # that feature.
       ATTENDANCE_API_KEY: devattendanceapikey
-      CANVAS_TOKEN: fG5BLbfZCiheKv6LJO13t1opFuTseKNAY6no6b7meHicN8UWsYAjaPU5TQFyB1TP
+      CANVAS_TOKEN: BEW8ldtbMypKZiCs8EmW2eQXfOoBpfOEwNJXwyvfIKZIpMgQzBfYUugc4V20oFgt
       BRAVEN_SSO_DOMAIN: ssoweb:3002
       BRAVEN_PORTAL_DOMAIN: canvasweb:3000
     working_dir: /var/www/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
 version: '3.5'
 
 services:
-  wordpress-db:
+
+  kitsdb:
     image: mysql:5.7
     volumes:
       - db_data:/var/lib/mysql
-    restart: always
+    # I kind of want to see when it goes down and solve it rather than always just restarting it.
+    #restart: always
     environment:
       MYSQL_ROOT_PASSWORD: pass
       MYSQL_DATABASE: wordpress
@@ -14,20 +16,31 @@ services:
     networks:
       - bravendev
 
-  wordpress:
+  kitsweb:
     build:
         context: .
+    command: /var/www/html/docker-compose/scripts/docker_compose_run.sh apache2-foreground
     depends_on:
-      - wordpress-db
+      - kitsdb
     ports:
-      - "8000:80"
-    restart: always
+      - "3005:80"
+    # I kind of want to see when it goes down and solve it rather than always just restarting it.
+    #restart: always
     environment:
-      WORDPRESS_DB_HOST: db:3306
+      # TODO: create attendance database on here
+      SERVERNAME: kitsweb
+      WORDPRESS_DB_HOST: kitsdb:3306
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DEBUG: 1
+      WORDPRESS_TABLE_PREFIX: bz_
+      WORDPRESS_FORCE_SSL_ADMIN: 0
+      ATTENDANCE_API_KEY: TODO
+      DB_ATTENDANCE_NAME: braven_attendance
+      CANVAS_TOKEN: TODO
+      BRAVEN_SSO_DOMAIN: ssoweb
+      BRAVEN_PORTAL_DOMAIN: canvasweb
     working_dir: /var/www/html
     volumes:
       - .:/var/www/html/

--- a/docker-compose/config/apache2.conf.template
+++ b/docker-compose/config/apache2.conf.template
@@ -1,4 +1,4 @@
-<VirtualHost *:80>
+<VirtualHost *:MYSERVERPORT>
 	# The ServerName directive sets the request scheme, hostname and port that
 	# the server uses to identify itself. This is used when creating
 	# redirection URLs. In the context of virtual hosts, the ServerName

--- a/docker-compose/config/apache2.conf.template
+++ b/docker-compose/config/apache2.conf.template
@@ -1,0 +1,36 @@
+<VirtualHost *:80>
+	# The ServerName directive sets the request scheme, hostname and port that
+	# the server uses to identify itself. This is used when creating
+	# redirection URLs. In the context of virtual hosts, the ServerName
+	# specifies what hostname must appear in the request's Host: header to
+	# match this virtual host. For the default virtual host (this file) this
+	# value is not decisive as it is used as a last resort host regardless.
+	# However, you must set it for any further virtual host explicitly.
+	ServerName MYSERVERNAME
+
+	ServerAdmin admin@bebraven.org
+	DocumentRoot /var/www/html
+
+  <Directory "/var/www/html">
+    Allow from all
+    Options -MultiViews
+  </Directory>
+
+	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+	# error, crit, alert, emerg.
+	# It is also possible to configure the loglevel for particular
+	# modules, e.g.
+	#LogLevel info ssl:warn
+
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+	# For most configuration files from conf-available/, which are
+	# enabled or disabled at a global level, it is possible to
+	# include a line for only one particular virtual host. For example the
+	# following line enables the CGI configuration for this host only
+	# after it has been globally disabled with "a2disconf".
+	#Include conf-available/serve-cgi-bin.conf
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/docker-compose/scripts/appconnect.sh
+++ b/docker-compose/scripts/appconnect.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose exec kitsweb /bin/bash

--- a/docker-compose/scripts/contentrefresh.sh
+++ b/docker-compose/scripts/contentrefresh.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+echo "Refreshing uploads content from kits-dev-files S3 bucket"
+if aws --version 2> /dev/null; then
+
+  # Note: not using gzip b/c this is additive and once you have the baseline set of uploads, then each subsequent
+  # run just syncs to changes
+  aws s3 sync 's3://kits-dev-files/uploads/' './wp-content/uploads/'
+  if [ $? -ne 0 ]
+  then
+    echo "Failed pulling uploads folder from kits-dev-files S3 bucket using:"
+    exit 1;
+  fi
+
+  aws s3 sync 's3://kits-dev-files/plugins/' './wp-content/plugins/'
+  if [ $? -ne 0 ]
+  then
+    echo "Failed pulling plugins folder from kits-dev-files S3 bucket using:"
+    exit 1;
+  fi
+
+else
+  # Install AWS CLI if it's not there
+  echo "Error: Please install 'aws'. E.g."
+  echo "   $ pip3 install awscli"
+  echo ""
+  echo "You must run 'aws configure' after to setup permissions. Enter your IAM Access Token and Secret. Use us-west-1 for the region."
+  exit 1;
+fi

--- a/docker-compose/scripts/dbconnect.sh
+++ b/docker-compose/scripts/dbconnect.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# This connects to the development database. The user and database name are in docker-compose.yml
+docker-compose exec kitsdb mysql -h kitsdb -P 3306 -u wordpress -pwordpress wordpress

--- a/docker-compose/scripts/dbrefresh.sh
+++ b/docker-compose/scripts/dbrefresh.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+echo "Refreshing your local dev database from the staging db"
+
+dbfilename='kits_dev_db_dump_latest.sql.gz'
+dbfilepathgz="/tmp/$dbfilename"
+dbfilename_attendance='kits_dev_attendance_db_dump.sql.gz'
+dbfilepathgz_attendance="/tmp/$dbfilename_attendance"
+
+aws s3 --region us-west-1 cp "s3://kits-dev-db-dumps/$dbfilename" $dbfilepathgz
+if [ $? -ne 0 ]
+then
+ echo "Failed downloading s3://kits-dev-db-dumps/$dbfilename"
+ echo "Make sure that awscli is installed: pip3 install awscli"
+ echo "Also, make sure and run 'aws configure' and put in your Access Key and Secret."
+ echo "Lastly, make sure your IAM account is in the Developers group. That's where the policy to access this bucket is defined."
+ exit 1;
+fi
+
+gunzip < $dbfilepathgz | docker-compose exec -T kitsdb mysql -h kitsdb -u wordpress "-pwordpress" wordpress
+if [ $? -ne 0 ]
+then
+   echo "Error: failed loading the dev database into the dev db. File we tried to load: $dbfilepathgz"
+   exit 1;
+fi
+
+rm $dbfilepathgz
+
+#aws s3 --region us-west-1 cp "s3://kits-dev-db-dumps/$dbfilename_attendance" $dbfilepathgz_attendance
+#if [ $? -ne 0 ]
+#then
+# echo "Failed downloading s3://kits-dev-db-dumps/$dbfilename_attendance"
+# exit 1;
+#fi
+#
+#gunzip < $dbfilepathgz_attendance| docker-compose exec -T kitsdb mysql -h kitsdb -u wordpress "-pwordpress" attendance
+#if [ $? -ne 0 ]
+#then
+#   echo "Error: failed loading the dev database into the dev db. File we tried to load: $dbfilepathgz_attendance"
+#   exit 1;
+#fi
+#
+#rm $dbfilepathgz_attendance
+#
+
+./docker-compose/scripts/contentrefresh.sh

--- a/docker-compose/scripts/dbrefresh.sh
+++ b/docker-compose/scripts/dbrefresh.sh
@@ -3,7 +3,7 @@ echo "Refreshing your local dev database from the staging db"
 
 dbfilename='kits_dev_db_dump_latest.sql.gz'
 dbfilepathgz="/tmp/$dbfilename"
-dbfilename_attendance='kits_dev_attendance_db_dump.sql.gz'
+dbfilename_attendance='kits_dev_attendance_db_dump_latest.sql.gz'
 dbfilepathgz_attendance="/tmp/$dbfilename_attendance"
 
 aws s3 --region us-west-1 cp "s3://kits-dev-db-dumps/$dbfilename" $dbfilepathgz
@@ -25,21 +25,32 @@ fi
 
 rm $dbfilepathgz
 
-#aws s3 --region us-west-1 cp "s3://kits-dev-db-dumps/$dbfilename_attendance" $dbfilepathgz_attendance
-#if [ $? -ne 0 ]
-#then
-# echo "Failed downloading s3://kits-dev-db-dumps/$dbfilename_attendance"
-# exit 1;
-#fi
-#
-#gunzip < $dbfilepathgz_attendance| docker-compose exec -T kitsdb mysql -h kitsdb -u wordpress "-pwordpress" attendance
-#if [ $? -ne 0 ]
-#then
-#   echo "Error: failed loading the dev database into the dev db. File we tried to load: $dbfilepathgz_attendance"
-#   exit 1;
-#fi
-#
-#rm $dbfilepathgz_attendance
-#
+aws s3 --region us-west-1 cp "s3://kits-dev-db-dumps/$dbfilename_attendance" $dbfilepathgz_attendance
+if [ $? -ne 0 ]
+then
+ echo "Failed downloading s3://kits-dev-db-dumps/$dbfilename_attendance"
+ exit 1;
+fi
 
+# to "Only logged in users can see the site" and also the setting "CAS Logins" to the proper stuff as shown in the
+# Kit Production Setup doc.
+gunzip < $dbfilepathgz_attendance| docker-compose exec -T kitsdb mysql -h kitsdb -u wordpress "-pwordpress" braven_attendance
+if [ $? -ne 0 ]
+then
+   echo "Error: failed loading the dev database into the dev db. File we tried to load: $dbfilepathgz_attendance"
+   exit 1;
+fi
+
+rm $dbfilepathgz_attendance
+
+# In the dev env, I logged into http://kitsweb:3005/wp-login.php?external=wordpress
+# Using the local admin account (same as prod) and configured this plugin to point to
+# the local SSO server. Then I just copied out the serialized value and am setting it here.
+# this is brittle b/c if you change it to something else and add or remove a character without
+# handling the serialized character counts and array counts, it will fail to deserialize.
+# We should do this using PHP code...
+devAuthSettings='a:45:{s:20:"access_who_can_login";s:14:"external_users";s:34:"access_role_receive_pending_emails";s:3:"---";s:34:"access_pending_redirect_to_message";s:0:"";s:34:"access_blocked_redirect_to_message";s:0:"";s:35:"access_email_approved_users_subject";s:0:"";s:32:"access_email_approved_users_body";s:0:"";s:19:"access_who_can_view";s:15:"logged_in_users";s:15:"access_redirect";s:5:"login";s:21:"access_public_warning";s:10:"no_warning";s:26:"access_redirect_to_message";s:28:"Dev Msg: No anonymous access";s:19:"access_default_role";s:10:"subscriber";s:15:"google_clientid";s:0:"";s:19:"google_clientsecret";s:0:"";s:19:"google_hosteddomain";s:0:"";s:3:"cas";s:1:"1";s:16:"cas_custom_label";s:0:"";s:8:"cas_host";s:6:"ssoweb";s:8:"cas_port";s:4:"3002";s:8:"cas_path";s:0:"";s:11:"cas_version";s:15:"CAS_VERSION_2_0";s:14:"cas_attr_email";s:0:"";s:19:"cas_attr_first_name";s:0:"";s:18:"cas_attr_last_name";s:0:"";s:14:"cas_auto_login";s:1:"1";s:9:"ldap_host";s:0:"";s:9:"ldap_port";s:0:"";s:16:"ldap_search_base";s:0:"";s:8:"ldap_uid";s:0:"";s:15:"ldap_attr_email";s:0:"";s:9:"ldap_user";s:0:"";s:13:"ldap_password";s:0:"";s:21:"ldap_lostpassword_url";s:0:"";s:20:"ldap_attr_first_name";s:0:"";s:19:"ldap_attr_last_name";s:0:"";s:17:"advanced_lockouts";a:5:{s:10:"attempts_1";s:0:"";s:10:"duration_1";s:0:"";s:10:"attempts_2";s:0:"";s:10:"duration_2";s:0:"";s:14:"reset_duration";s:0:"";}s:22:"advanced_hide_wp_login";s:1:"1";s:19:"advanced_admin_menu";s:3:"top";s:17:"advanced_usermeta";s:0:"";s:34:"access_should_email_approved_users";s:0:"";s:6:"google";s:0:"";s:24:"cas_attr_update_on_login";s:0:"";s:4:"ldap";s:0:"";s:8:"ldap_tls";s:0:"";s:25:"ldap_attr_update_on_login";s:0:"";s:27:"advanced_override_multisite";s:0:"";}'
+echo "update bz_options set option_value = '$devAuthSettings' where option_name = 'auth_settings';" | docker-compose exec -T kitsdb mysql -h kitsdb -P 3306 -u wordpress -pwordpress wordpress
+
+# Now get the up to date plugins and uploads content.
 ./docker-compose/scripts/contentrefresh.sh

--- a/docker-compose/scripts/docker_compose_run.sh
+++ b/docker-compose/scripts/docker_compose_run.sh
@@ -126,6 +126,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     BRAVEN_SSO_DOMAIN
     BRAVEN_PORTAL_DOMAIN
     DB_ATTENDANCE_NAME
+    ATTENDANCE_TRACKER_NOTIFY_METHOD
 	)
 	haveConfig=
 	for e in "${envs[@]}"; do
@@ -231,6 +232,7 @@ EOPHP
 		set_config 'BRAVEN_SSO_DOMAIN' "$BRAVEN_SSO_DOMAIN"
 		set_config 'BRAVEN_PORTAL_DOMAIN' "$BRAVEN_PORTAL_DOMAIN"
 		set_config 'DB_ATTENDANCE_NAME' "$DB_ATTENDANCE_NAME"
+		set_config 'ATTENDANCE_TRACKER_NOTIFY_METHOD' "$ATTENDANCE_TRACKER_NOTIFY_METHOD"
 
 		for unique in "${uniqueEnvs[@]}"; do
 			uniqVar="WORDPRESS_$unique"

--- a/docker-compose/scripts/docker_compose_run.sh
+++ b/docker-compose/scripts/docker_compose_run.sh
@@ -78,6 +78,8 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   # The docker image has a template in place for the apache config, but we need to set
   # the actual values based on the ENV vars passed in
   sed -i "s/MYSERVERNAME/$SERVERNAME/g" /etc/apache2/sites-available/000-default.conf
+  sed -i "s/MYSERVERPORT/$SERVERPORT/g" /etc/apache2/sites-available/000-default.conf
+  sed -i "s/80/$SERVERPORT/g" /etc/apache2/ports.conf
 
   if [ ! -e .htaccess ]; then
 		# NOTE: The "Indexes" option is disabled in the php:apache base image

--- a/docker-compose/scripts/rebuild.sh
+++ b/docker-compose/scripts/rebuild.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker-compose down
+docker-compose up -d --force-recreate --build

--- a/docker-compose/scripts/restart.sh
+++ b/docker-compose/scripts/restart.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker-compose down
+docker-compose up -d

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,290 @@
+#!/bin/bash
+set -euo pipefail
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+	if [ "$(id -u)" = '0' ]; then
+		case "$1" in
+			apache2*)
+				user="${APACHE_RUN_USER:-www-data}"
+				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
+				;;
+			*) # php-fpm
+				user='www-data'
+				group='www-data'
+				;;
+		esac
+	else
+		user="$(id -u)"
+		group="$(id -g)"
+	fi
+
+	if [ ! -e index.php ] && [ ! -e wp-includes/version.php ]; then
+		# if the directory exists and WordPress doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
+		if [ "$(id -u)" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
+			chown "$user:$group" .
+		fi
+
+		echo >&2 "WordPress not found in $PWD - copying now..."
+		if [ -n "$(ls -A)" ]; then
+			echo >&2 "WARNING: $PWD is not empty! (copying anyhow)"
+		fi
+		sourceTarArgs=(
+			--create
+			--file -
+			--directory /usr/src/wordpress
+			--owner "$user" --group "$group"
+		)
+		targetTarArgs=(
+			--extract
+			--file -
+		)
+		if [ "$user" != '0' ]; then
+			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+			targetTarArgs+=( --no-overwrite-dir )
+		fi
+		tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
+		echo >&2 "Complete! WordPress has been successfully copied to $PWD"
+		if [ ! -e .htaccess ]; then
+			# NOTE: The "Indexes" option is disabled in the php:apache base image
+			cat > .htaccess <<-'EOF'
+				# BEGIN WordPress
+				<IfModule mod_rewrite.c>
+				RewriteEngine On
+				RewriteBase /
+				RewriteRule ^index\.php$ - [L]
+				RewriteCond %{REQUEST_FILENAME} !-f
+				RewriteCond %{REQUEST_FILENAME} !-d
+				RewriteRule . /index.php [L]
+				</IfModule>
+				# END WordPress
+			EOF
+			chown "$user:$group" .htaccess
+		fi
+	fi
+
+	# allow any of these "Authentication Unique Keys and Salts." to be specified via
+	# environment variables with a "WORDPRESS_" prefix (ie, "WORDPRESS_AUTH_KEY")
+	uniqueEnvs=(
+		AUTH_KEY
+		SECURE_AUTH_KEY
+		LOGGED_IN_KEY
+		NONCE_KEY
+		AUTH_SALT
+		SECURE_AUTH_SALT
+		LOGGED_IN_SALT
+		NONCE_SALT
+	)
+	envs=(
+		WORDPRESS_DB_HOST
+		WORDPRESS_DB_USER
+		WORDPRESS_DB_PASSWORD
+		WORDPRESS_DB_NAME
+		WORDPRESS_DB_CHARSET
+		WORDPRESS_DB_COLLATE
+		"${uniqueEnvs[@]/#/WORDPRESS_}"
+		WORDPRESS_TABLE_PREFIX
+		WORDPRESS_DEBUG
+		WORDPRESS_CONFIG_EXTRA
+	)
+	haveConfig=
+	for e in "${envs[@]}"; do
+		file_env "$e"
+		if [ -z "$haveConfig" ] && [ -n "${!e}" ]; then
+			haveConfig=1
+		fi
+	done
+
+	# linking backwards-compatibility
+	if [ -n "${!MYSQL_ENV_MYSQL_*}" ]; then
+		haveConfig=1
+		# host defaults to "mysql" below if unspecified
+		: "${WORDPRESS_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"
+		if [ "$WORDPRESS_DB_USER" = 'root' ]; then
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+		else
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_PASSWORD:-}}"
+		fi
+		: "${WORDPRESS_DB_NAME:=${MYSQL_ENV_MYSQL_DATABASE:-}}"
+	fi
+
+	# only touch "wp-config.php" if we have environment-supplied configuration values
+	if [ "$haveConfig" ]; then
+		: "${WORDPRESS_DB_HOST:=mysql}"
+		: "${WORDPRESS_DB_USER:=root}"
+		: "${WORDPRESS_DB_PASSWORD:=}"
+		: "${WORDPRESS_DB_NAME:=wordpress}"
+		: "${WORDPRESS_DB_CHARSET:=utf8}"
+		: "${WORDPRESS_DB_COLLATE:=}"
+
+		# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
+		# https://github.com/docker-library/wordpress/issues/116
+		# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
+		sed -ri -e 's/\r$//' wp-config*
+
+		if [ ! -e wp-config.php ]; then
+			awk '
+				/^\/\*.*stop editing.*\*\/$/ && c == 0 {
+					c = 1
+					system("cat")
+					if (ENVIRON["WORDPRESS_CONFIG_EXTRA"]) {
+						print "// WORDPRESS_CONFIG_EXTRA"
+						print ENVIRON["WORDPRESS_CONFIG_EXTRA"] "\n"
+					}
+				}
+				{ print }
+			' wp-config-sample.php > wp-config.php <<'EOPHP'
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+	$_SERVER['HTTPS'] = 'on';
+}
+
+EOPHP
+			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
+		fi
+
+		# see http://stackoverflow.com/a/2705678/433558
+		sed_escape_lhs() {
+			echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
+		}
+		sed_escape_rhs() {
+			echo "$@" | sed -e 's/[\/&]/\\&/g'
+		}
+		php_escape() {
+			local escaped="$(php -r 'var_export(('"$2"') $argv[1]);' -- "$1")"
+			if [ "$2" = 'string' ] && [ "${escaped:0:1}" = "'" ]; then
+				escaped="${escaped//$'\n'/"' + \"\\n\" + '"}"
+			fi
+			echo "$escaped"
+		}
+		set_config() {
+			key="$1"
+			value="$2"
+			var_type="${3:-string}"
+			start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
+			end="\);"
+			if [ "${key:0:1}" = '$' ]; then
+				start="^(\s*)$(sed_escape_lhs "$key")\s*="
+				end=";"
+			fi
+			sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		}
+
+		set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
+		set_config 'DB_USER' "$WORDPRESS_DB_USER"
+		set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
+		set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
+		set_config 'DB_CHARSET' "$WORDPRESS_DB_CHARSET"
+		set_config 'DB_COLLATE' "$WORDPRESS_DB_COLLATE"
+
+		for unique in "${uniqueEnvs[@]}"; do
+			uniqVar="WORDPRESS_$unique"
+			if [ -n "${!uniqVar}" ]; then
+				set_config "$unique" "${!uniqVar}"
+			else
+				# if not specified, let's generate a random value
+				currentVal="$(sed -rn -e "s/define\(\s*(([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\s*\);/\4/p" wp-config.php)"
+				if [ "$currentVal" = 'put your unique phrase here' ]; then
+					set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
+				fi
+			fi
+		done
+
+		if [ "$WORDPRESS_TABLE_PREFIX" ]; then
+			set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+		fi
+
+		if [ "$WORDPRESS_DEBUG" ]; then
+			set_config 'WP_DEBUG' 1 boolean
+		fi
+
+		if ! TERM=dumb php -- <<'EOPHP'
+<?php
+// database might not exist, so let's try creating it (just to be safe)
+
+$stderr = fopen('php://stderr', 'w');
+
+// https://codex.wordpress.org/Editing_wp-config.php#MySQL_Alternate_Port
+//   "hostname:port"
+// https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
+//   "hostname:unix-socket-path"
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
+$port = 0;
+if (is_numeric($socket)) {
+	$port = (int) $socket;
+	$socket = null;
+}
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
+
+$maxTries = 10;
+do {
+	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);
+	if ($mysql->connect_error) {
+		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
+		--$maxTries;
+		if ($maxTries <= 0) {
+			exit(1);
+		}
+		sleep(3);
+	}
+} while ($mysql->connect_error);
+
+if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($dbName) . '`')) {
+	fwrite($stderr, "\n" . 'MySQL "CREATE DATABASE" Error: ' . $mysql->error . "\n");
+	$mysql->close();
+	exit(1);
+}
+
+$mysql->close();
+EOPHP
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
+	fi
+
+	# now that we're definitely done writing configuration, let's clear out the relevant envrionment variables (so that stray "phpinfo()" calls don't leak secrets from our code)
+	for e in "${envs[@]}"; do
+		unset "$e"
+	done
+fi
+
+exec "$@"

--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -37,6 +37,12 @@ define('DB_CHARSET', 'utf8');
 /** The Database Collate type. Don't change this if in doubt. */
 define('DB_COLLATE', '');
 
+define('ATTENDANCE_API_KEY', 'your key');
+define('CANVAS_TOKEN', 'your token');
+define('BRAVEN_SSO_DOMAIN', 'your sso domain');
+define('BRAVEN_PORTAL_DOMAIN', 'your canvas domain');
+define('DB_ATTENDANCE_NAME', 'your attedance db name');
+
 /**#@+
  * Authentication Unique Keys and Salts.
  *
@@ -63,7 +69,7 @@ define('NONCE_SALT',       'put your unique phrase here');
  * You can have multiple installations in one database if you give each
  * a unique prefix. Only numbers, letters, and underscores please!
  */
-$table_prefix  = 'wp_';
+$table_prefix  = 'bz_';
 
 /**
  * For developers: WordPress debugging mode.
@@ -78,6 +84,11 @@ $table_prefix  = 'wp_';
  * @link https://codex.wordpress.org/Debugging_in_WordPress
  */
 define('WP_DEBUG', false);
+define( 'WP_DEBUG_LOG', false );
+
+/** Only let logging into wp-admin using SSL */
+define('FORCE_SSL_ADMIN', true);
+
 
 /* That's all, stop editing! Happy blogging. */
 

--- a/wp-content/plugins/authorizer/vendor/CAS-1.3.4/CAS/Client.php
+++ b/wp-content/plugins/authorizer/vendor/CAS-1.3.4/CAS/Client.php
@@ -314,10 +314,18 @@ class CAS_Client
     {
         // the URL is build only when needed
         if ( empty($this->_server['base_url']) ) {
-            $this->_server['base_url'] = 'https://' . $this->_getServerHostname();
-            if ($this->_getServerPort()!=443) {
-                $this->_server['base_url'] .= ':'
-                .$this->_getServerPort();
+            // Sooo, to get this plugin working in a dev env, I had to change this method
+            // It now defaults to http instead of https unless you set port 443 or leave it blank.
+            // When we upgrade, we're going to have to deal with merge conflicts and make this
+            // change in the upgraded code. TODO: figure out a way to make this change outside
+            // the plugin code so that it works on upgrades!
+            // NOTE: I tried to use protocol relative URLs, like '//' . $this->_getServerHostname(); but
+            // this stuff uses cUrl under the covers and cUrl can't handle those b/c it's protocol agnostic
+            if ($this->_getServerPort()==443 || empty( $this->_getServerPort() ) ) {
+                $this->_server['base_url'] = 'https://' . $this->_getServerHostname();
+            }
+            else {
+                $this->_server['base_url'] = 'http://' . $this->_getServerHostname() . ':' . $this->_getServerPort();
             }
             $this->_server['base_url'] .= $this->_getServerURI();
         }


### PR DESCRIPTION
This PR takes the official PHP Docker image for PHP 7.0.8 (the version we're using in staging and prod) https://hub.docker.com/_/php and customizes it to work in our dev env, where if you bring it up and run `docker-compose/scripts/dbrefresh.sh` then if the other apps are running locally, it will talk to them and work. E.g. you can login against your local SSO server, it takes attendance using the local Canvas server info, etc. See https://github.com/beyond-z/development for more info.

The `docker-compose/scripts/docker_compose_run.sh` script is adapted from this: https://github.com/docker-library/wordpress/blob/master/docker-entrypoint.sh

Testing:
- I brought up all other local docker dev envs mentioned in the `development` repo, then I ran `docker-compose up -d` and then `./docker-compose/scripts/dbrefresh.sh`. When I went to `http://kitsweb` I was able to login as any user in the dev database and see the kits, including attendance tracking stuff if I logged in as an admin or an LC with Fellows in their cohort (Section in Canvas).