### PR TITLE
Add a fallback height for attendance in IE

### DIFF
--- a/wp-content/themes/bzLLKit/functions.php
+++ b/wp-content/themes/bzLLKit/functions.php
@@ -1058,6 +1058,8 @@ function bz_attendance($atts, $content = null) {
     	$what = $atts["event"];
 
     return "<iframe onload=\"
+        // fall back to a minimum height because the iframe document height trick doesn't work in IE
+        this.style.minHeight = '500px';
         this.style.height = (30 + this.contentWindow.document.body.scrollHeight) + 'px';
         this.style.border = 'none';
         this.style.width = '".$width."%';
@@ -1067,6 +1069,8 @@ function bz_attendance($atts, $content = null) {
         try {
                 (function(ele) {
                 var i = new IntersectionObserver(function(entries) {
+                        // fall back to a minimum height because the iframe document height trick doesn't work in IE
+                        ele.style.minHeight = '500px';
                         ele.style.height = (30 + ele.contentWindow.document.body.scrollHeight) + 'px';
                 });
                 i.observe(ele);


### PR DESCRIPTION
Ticket: https://bebraven.zendesk.com/agent/tickets/292

Summary: One of our LCs can only use IE, and her attendance shows up in a tiny box. This issue does not impact other browsers.

Fix: IE doesn't know the height of the document inside the iframe, so I just set a `min-height` of `500px`, which will give enough room for most sections to take attendance without scrolling. In the edge case where an LC uses IE and has more students than fit in 500px, they'll just get a scrollbar inside the iframe.