### PR TITLE
Fix pushing attendance from Kits to Canvas gradebook.

### DIFF
--- a/attendance.php
+++ b/attendance.php
@@ -323,9 +323,6 @@ function bz_current_full_url() {
 }
 
 function sso() {
-	global $WP_CONFIG;
-
-
 	if(isset($_SESSION["sso_service"]) && isset($_SESSION["coming_from"]) && isset($_GET["ticket"])) {
 		// validate ticket from the SSO server
 
@@ -415,12 +412,11 @@ requireLogin();
 	}
 
 	function get_user_course_id($email) {
-		global $WP_CONFIG;
 		global $braven_courses;
 
 		$ch = curl_init();
     $baseUrl = getPortalBaseUrl();
-		$url = $baseUrl . '/bz/courses_for_email?email='.(urlencode($email)). '&access_token=' . urlencode($WP_CONFIG["CANVAS_TOKEN"]);
+		$url = $baseUrl . '/bz/courses_for_email?email='.(urlencode($email)). '&access_token=' . urlencode(CANVAS_TOKEN);
 
     // Uncomment to log above call to browswer console so you can login to server and try to curl it to see what you get.
     //echo("<script>console.log('Attendance tracker getting course ID for user by calling: " . $url . "');</script>");

--- a/attendance_api.php
+++ b/attendance_api.php
@@ -38,8 +38,6 @@ if(php_sapi_name() == 'cli') {
 	echo "*****\nRunning at " . date('r') . "\n";
 
 	function set_canvas_attendance_info($course_id, $column_number, $uid, $text) {
-		global $WP_CONFIG;
-
 		$ch = curl_init();
     $baseUrl = getPortalBaseUrl();
     $url = $baseUrl . '/api/v1/courses/'.$course_id.'/custom_gradebook_columns/'.$column_number.'/data/'.$uid;
@@ -48,7 +46,7 @@ if(php_sapi_name() == 'cli') {
 
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-		curl_setopt($ch, CURLOPT_POSTFIELDS, urlencode("column_data[content]")."=".urlencode($text) . '&access_token='.urlencode($WP_CONFIG["CANVAS_TOKEN"]));
+		curl_setopt($ch, CURLOPT_POSTFIELDS, urlencode("column_data[content]")."=".urlencode($text) . '&access_token='.urlencode(CANVAS_TOKEN));
 		$answer = curl_exec($ch);
 		curl_close($ch);
 	}
@@ -56,12 +54,9 @@ if(php_sapi_name() == 'cli') {
 	function get_canvas_attendance_column_id($course_id) {
 		// first, try to get an existing one called Attendance and return ID
 		// and if it isn't there, go ahead and create one and return the ID
-
-		global $WP_CONFIG;
-
 		$ch = curl_init();
     $baseUrl = getPortalBaseUrl();
-    $url = $baseUrl . '/api/v1/courses/'.$course_id.'/custom_gradebook_columns?access_token='.urlencode($WP_CONFIG["CANVAS_TOKEN"]);
+    $url = $baseUrl . '/api/v1/courses/'.$course_id.'/custom_gradebook_columns?access_token='.urlencode(CANVAS_TOKEN);
 
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
@@ -86,7 +81,7 @@ if(php_sapi_name() == 'cli') {
 		curl_setopt($ch, CURLOPT_POSTFIELDS,
 			urlencode("column[title]")."=Attendance" .
 			'&'.urlencode("column[read_only]")."=true" .
-			'&access_token='.urlencode($WP_CONFIG["CANVAS_TOKEN"]));
+			'&access_token='.urlencode(CANVAS_TOKEN));
 		$answer = curl_exec($ch);
 		curl_close($ch);
 
@@ -100,6 +95,11 @@ if(php_sapi_name() == 'cli') {
 		$column_number = get_canvas_attendance_column_id($course_id);
 		$result = get_attendance_api_result($course_id, $cohort_info["students"]);
 
+    // TODO: this is brutally slow since it loops over all students in all active courses and updates the value through the API one at a time.
+    // Either figure out how to set the values in bulk or maybe check timestamps of last time 
+    // data was sent (or query canvas for last time value was updated on the canvas end)
+    // vs last time attendance status was updated and only send new ones.
+    // Or maybe just pull all attendance data from canvas in one go per course, then only send updates for changed values.
 		foreach($result["statuses"] as $uid => $status) {
 			set_canvas_attendance_info($course_id, $column_number, $uid, $status["total_present"] . "/". $status["total_events"]);
 		}
@@ -107,7 +107,7 @@ if(php_sapi_name() == 'cli') {
 } else {
 	// if calling via web, we do an access token chck
 
-	if(!isset($_REQUEST["access_token"]) || $_REQUEST["access_token"] != $WP_CONFIG["ATTENDANCE_API_KEY"]) {
+	if(!isset($_REQUEST["access_token"]) || $_REQUEST["access_token"] != ATTENDANCE_API_KEY) {
 		die("Unauthorized");
 	}
 

--- a/attendance_cron.php
+++ b/attendance_cron.php
@@ -87,8 +87,6 @@ function load_attendance_result($course_id, $event_name, $students_info) {
 }
 
 function send_sms($to, $message) {
-	global $WP_CONFIG;
-
 	$to = preg_replace('/[^0-9]/', '', $to);
 	if(strlen($to) == 10)
 		$to = "1" . $to;
@@ -98,10 +96,10 @@ function send_sms($to, $message) {
 		throw new Exception("bad phone number $to");
 
 	$ch = curl_init();
-	$url = "https://api.twilio.com/2010-04-01/Accounts/".$WP_CONFIG["TWILIO_SID"]."/Messages.json";
-	$auth = $WP_CONFIG["TWILIO_SID"] . ":" . $WP_CONFIG["TWILIO_TOKEN"];
+	$url = "https://api.twilio.com/2010-04-01/Accounts/".TWILIO_SID."/Messages.json";
+	$auth = TWILIO_SID . ":" . TWILIO_TOKEN;
 
-	$post  = "From=".urlencode($WP_CONFIG['TWILIO_FROM'])."&";
+	$post  = "From=".urlencode(TWILIO_FROM)."&";
 	$post .= "To=".urlencode($to)."&";
 	$post .= "Body=".urlencode($message);
 
@@ -207,5 +205,5 @@ echo "*****\nRunning at " . date('r') . "\n";
 
 foreach($braven_courses as $name => $course_id) {
 	echo "Checking course $course_id\n";
-	check_attendance_from_canvas($course_id, $WP_CONFIG["ATTENDANCE_TRACKER_NOTIFY_METHOD"]);
+	check_attendance_from_canvas($course_id, ATTENDANCE_TRACKER_NOTIFY_METHOD);
 }

--- a/attendance_shared.php
+++ b/attendance_shared.php
@@ -1,19 +1,5 @@
 <?php
-$WP_CONFIG = array();
-
-function bzLoadWpConfig() {
-	global $WP_CONFIG;
-
-	$out = array();
-	preg_match_all("/define\('([A-Z_0-9]+)', '(.*)'\);/", file_get_contents("wp-config.php"), $out, PREG_SET_ORDER);
-
-	foreach($out as $match) {
-		$WP_CONFIG[$match[1]] = $match[2];
-	}
-}
-
-bzLoadWpConfig();
-
+require_once("wp-config.php");
 require_once("courses.php");
 
 function get_lc_excused_status($event_id, $lc_email) {
@@ -41,8 +27,6 @@ function get_lc_excused_status($event_id, $lc_email) {
 
 
 function get_canvas_events($course_id, $start_date, $end_date) {
-	global $WP_CONFIG;
-
 	$additional = "";
 	if($start_date !== null)
 		$additional .= "&start_date=".urlencode($start_date);
@@ -51,7 +35,7 @@ function get_canvas_events($course_id, $start_date, $end_date) {
 
 	$ch = curl_init();
   $baseUrl = getPortalBaseUrl();
-  $url = $baseUrl . '/api/v1/calendar_events?per_page=500&context_codes[]=course_'.(urlencode($course_id)). '&access_token=' . urlencode($WP_CONFIG["CANVAS_TOKEN"]) . $additional;
+  $url = $baseUrl . '/api/v1/calendar_events?per_page=500&context_codes[]=course_'.(urlencode($course_id)). '&access_token=' . urlencode(CANVAS_TOKEN) . $additional;
 	curl_setopt($ch, CURLOPT_URL, $url);
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 	$answer = curl_exec($ch);
@@ -119,23 +103,39 @@ function populate_times_from_canvas($course_id) {
 	}
 }
 
+// Note: originally the check for which protocol to use was the following:
+//   if(isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on")
+// but that didn't work when this script was run from the command line as a
+// cronjob in order to push attendance data to the portal (canvas).
+// So we need to check wp-config.php instead
 function getProtocol(){
-  $protocol = "http";
-  if(isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on")
-    $protocol .= "s";
-  return $protocol .= "://";
+  static $protocol;
+  if (is_null($protocol)){
+    // I know, this config value isn't exactly what we should use, but rather than
+    // defining a new config, if we're running SSL, we should require this to be set.
+    if (FORCE_SSL_ADMIN){
+      $protocol = "https://";
+    } else {
+      $protocol = "http://";
+    }
+  }
+  return $protocol;
 }
 
 function getPortalBaseUrl() {
-  global $WP_CONFIG;
-  $protocol = getProtocol();
-	return $protocol . $WP_CONFIG["BRAVEN_PORTAL_DOMAIN"];
+  static $portalBaseUrl;
+  if (is_null($portalBaseUrl)){
+    $portalBaseUrl = getProtocol() . BRAVEN_PORTAL_DOMAIN;
+  }
+  return $portalBaseUrl;
 }
 
 function getSSOBaseUrl() {
-  global $WP_CONFIG;
-  $protocol = getProtocol();
-	return $protocol . $WP_CONFIG["BRAVEN_SSO_DOMAIN"];
+  static $ssoBaseUrl;
+  if (is_null($ssoBaseUrl)){
+    $ssoBaseUrl = getProtocol() . BRAVEN_SSO_DOMAIN;
+  }
+  return $ssoBaseUrl;
 }
 
 function isTa($user_email, $cohort_info) {
@@ -143,14 +143,12 @@ function isTa($user_email, $cohort_info) {
 }
 
 function get_cohorts_info($course_id) {
-	global $WP_CONFIG;
-
 	if(isset($_SESSION["cohort_course_info_$course_id"]))
 		return $_SESSION["cohort_course_info_$course_id"];
 
 	$ch = curl_init();
   $baseUrl = getPortalBaseUrl();
-	$url = $baseUrl . '/bz/course_cohort_information?course_ids[]='.((int) $course_id). '&access_token=' . urlencode($WP_CONFIG["CANVAS_TOKEN"]);
+	$url = $baseUrl . '/bz/course_cohort_information?course_ids[]='.((int) $course_id). '&access_token=' . urlencode(CANVAS_TOKEN);
 
   // Uncomment to log above call to browswer console so you can login to server and try to curl it to see what you get.
   // Note: curl has to be run like: curl --globoff -vvv "http://canvasweb:3000/bz/course_cohort_information?course_ids[]=71&access_token=<yourtoken>"
@@ -341,5 +339,5 @@ $pdo_opt = [
 	PDO::ATTR_EMULATE_PREPARES   => false,
 ];
 
-$pdo = new PDO("mysql:host={$WP_CONFIG["DB_HOST"]};dbname={$WP_CONFIG["DB_ATTENDANCE_NAME"]};charset=utf8mb4", $WP_CONFIG["DB_USER"], $WP_CONFIG["DB_PASSWORD"], $pdo_opt);
+$pdo = new PDO("mysql:host=" . DB_HOST . ";dbname=" . DB_ATTENDANCE_NAME . ";charset=utf8mb4", DB_USER, DB_PASSWORD, $pdo_opt);
 


### PR DESCRIPTION
A cronjob runs on the Kits server that runs the attendance_api.php
script. However, I had changed the attendance_shared.php to check for the
server's http vs https situation when constructing URLs. Since the cronjob 
is just a command line thingie, none of that was set. Now, we choose the 
protocol based on the FORCE_SSL_ADMIN config value in wp-config.php. 
If we have SSL on, that should be set. This change looks a bit bigger than it 
should b/c the code was using a buggy way to load wp-config values (the regex
didn't account for either no space or more than one space between the key/value
and it also didn't handle values not in single quotes (e.g. booleans and integers 
weren't picked up.) Now it just loads the file directly as a PHP
script and directly references the defined consts.

TESTING:
- I can still login as an LC and see the Fellows in my cohort and the
  value I choose for present vs absent is written to the database and
read on load.
- I ran `php attendance_api.php` and it successfully calls in the
  canvas server. However, I'm still struggling to actuall get the
gradebook to populate b/c the event date/times for each Learning Lab
(aka event) are not setup properly. Working with the team to get that
done in prod and getting this PR up so I can test that last tricky bit
in staging b/c my dev env is stupid slow.