### PR TITLE
Don't treat "test" accounts as staff accounts for attendance tracking.

### DIFF
--- a/attendance.php
+++ b/attendance.php
@@ -444,6 +444,11 @@ requireLogin();
 	}
 
 	$is_staff = strpos($_SESSION["user"], "@bebraven.org") !== FALSE || strpos($_SESSION["user"], "@beyondz.org") !== FALSE;
+        // For test accounts, treat them as users, not staff, b/c we want to mimic the user experience with test accounts
+        // and if we need to do staff stuff, we should use actual bebraven.org accounts.
+        // Example test account: brian+testblah@bebraven.org
+	if (preg_match('/\+test.*@bebraven.org/', $_SESSION["user"]))
+          $is_staff = false;
 
 	if(isset($_POST["operation"])) {
 		switch($_POST["operation"]) {


### PR DESCRIPTION
We want to be able to test the LC experience using test accounts,
like brian+testblah@bebraven.org, so don't treat them as staff just
b/c they have an @bebraven.org email address. Only true staff accounts
should be treated as such.

TEST PLAN:
- Create a test LC account, brian+testlc1@bebraven.org, enroll them in
  a current, active course in the portal as a TA for a section with
  students in it. Login to http://kitsweb as that test LC, go to
  the Unlock Your Hustle kit for the course that LC is in (actually
  any kit with attendance tracking) and expand the "TAKE ATTENDANCE"
  section. They should not see the dropdown to switch between cohorts
  or see all Fellows in the course, they should only see the Fellows
  in their section (aka cohort).