### PR TITLE
Fix attendance data being pushed to the Portal gradebook for real this time.

### DIFF
--- a/attendance.php
+++ b/attendance.php
@@ -597,6 +597,7 @@ requireLogin();
 		foreach($cohort_info["sections"] as $section) {
 			$students = array();
 			foreach($section["enrollments"] as $enrollment) {
+				// TODO: if My Cohort Info isn't set, these three variables maybe empty/null. Handle this.
 				$enrollment["lc_name"] = $section["lc_name"];
 				$enrollment["lc_email"] = strtolower($section["lc_email"]);
 				$enrollment["section_name"] = $section["name"];


### PR DESCRIPTION
Boy oh boy, there is alot going on here. Some context:
  1) There is a cronjob that runs in the middle of the night on Sunday
     which calls attendance_api.php in order to sync the attendance data
     to the Portal.
  2) There is a cronjob which runs attendance_cron.php hourly to see if we
     need to send a text message to the LC reminding them to take attendance (aka auto-nags).
  3) My Cohort Info is a .csv that regions upload to the Portal which gives information about
     the LCs and TAs for each cohort. This is used for auto-nag primarily.
  4) The calendar in the Portal is expected to have an LL event, per cohort (aka section) with
     the end_at time set and with the event name matching the format:
     "Learning Lab #: LL Name (Cohort Name)" e.g. "Learning Lab 5: Unlock Your Hustle (SJSU Wendy (Wed))"

This commit is simply adding a call to the weekly attendance_api.php cron to populate the
LL event times in the local database before trying to figure out what attendance data to send
to the Portal. I have NO CLUE how this was working in the past. Maybe an engineer was manually running
this at the beginning of the semester once the Portal calendar was all setup and then it just worked the
rest of the semester? Either way, it will happen weekly now so that the data will flow (assuming
everything is setup properly. I'm working with folks to make sure that's the case and will
document this as part of the Portal launch checklist.

Note: there is an outstanding bug that may or may need to be fixed in a followup commit. I need to talk
to folks about it. The "Storytelling As Leadership Workshop" event is not in that format so the
attendance total isn't reflected in the gradebook.

TEST PLAN:
- Add a couple fellows in a specific section (aka cohort) in the Portal.
- Create LL events on the Portal calendar in the format above with the start and
  end-date set for that section. Make some in the past and some in the future.
- Upload a My Cohort Info sheet with information about that section in the Portal.
- Login as the LC for that section in the Kits and mark attendance for the events in the past.
- Run the attendance_api.php script.
- Login to the Portal and make sure the accurate attendance is reflected in the gradebook.
  - Note: it should show <number of LLs in the past marked present / total LLs in the past)