### PR TITLE
Fix attendance tracker populate_times_from_canvas() method. Handle pagination

### DIFF
--- a/attendance_api.php
+++ b/attendance_api.php
@@ -4,135 +4,135 @@ date_default_timezone_set("UTC");
 
 function get_attendance_api_result($course_id, $users) {
 
-	// I want events and statuses.
+    // I want events and statuses.
 
-	$response = array("events" => get_all_events($course_id), "statuses" => array());
-	$events_in_the_past = 0;
-	foreach($response["events"] as $event) {
-		if($event["event_time"] && strtotime($event["event_time"]) < time())
-			$events_in_the_past++;
-	}
+    $response = array("events" => get_all_events($course_id), "statuses" => array());
+    $events_in_the_past = 0;
+    foreach($response["events"] as $event) {
+        if($event["event_time"] && strtotime($event["event_time"]) < time())
+            $events_in_the_past++;
+    }
 
-	foreach($response["events"] as &$event) {
-		$event["statuses"] = load_student_status($event["id"], $users)["result"];
-		foreach($event["statuses"] as $user_id => $user_status) {
-			if(!isset($response["statuses"][$user_id]))
-				$response["statuses"][$user_id] = array("events" => array(), "total_present" => 0, "total_events" => $events_in_the_past);
-			$response["statuses"][$user_id]["events"][] = $user_status;
-			if($user_status === "true" || $user_status === "late") {
-				// only if it is in the past do we want to set this count
-				if($event["event_time"] && strtotime($event["event_time"]) < time())
-					$response["statuses"][$user_id]["total_present"] += 1;
-			}
-		}
-	}
+    foreach($response["events"] as &$event) {
+        $event["statuses"] = load_student_status($event["id"], $users)["result"];
+        foreach($event["statuses"] as $user_id => $user_status) {
+            if(!isset($response["statuses"][$user_id]))
+                $response["statuses"][$user_id] = array("events" => array(), "total_present" => 0, "total_events" => $events_in_the_past);
+            $response["statuses"][$user_id]["events"][] = $user_status;
+            if($user_status === "true" || $user_status === "late") {
+                // only if it is in the past do we want to set this count
+                if($event["event_time"] && strtotime($event["event_time"]) < time())
+                    $response["statuses"][$user_id]["total_present"] += 1;
+            }
+        }
+    }
 
-	return $response;
+    return $response;
 }
 
 if(php_sapi_name() == 'cli') {
-	// if calling it from the command line, instead sync it with Canvas
-	// via the api bridges
+    // if calling it from the command line, instead sync it with Canvas
+    // via the api bridges
 
-	echo "\n*****\nRunning at " . date('r') . "\n";
+    echo "\n*****\nRunning at " . date('r') . "\n";
 
-	function set_canvas_attendance_info($course_id, $column_number, $uid, $text) {
-		$ch = curl_init();
+    function set_canvas_attendance_info($course_id, $column_number, $uid, $text) {
+        $ch = curl_init();
     $baseUrl = getPortalBaseUrl();
     $url = $baseUrl . '/api/v1/courses/'.$course_id.'/custom_gradebook_columns/'.$column_number.'/data/'.$uid;
 
-		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT");
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT");
 
-		curl_setopt($ch, CURLOPT_URL, $url);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-		curl_setopt($ch, CURLOPT_POSTFIELDS, urlencode("column_data[content]")."=".urlencode($text) . '&access_token='.urlencode(CANVAS_TOKEN));
-		$answer = curl_exec($ch);
-		curl_close($ch);
-	}
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, urlencode("column_data[content]")."=".urlencode($text) . '&access_token='.urlencode(CANVAS_TOKEN));
+        $answer = curl_exec($ch);
+        curl_close($ch);
+    }
 
-	function get_canvas_attendance_column_id($course_id) {
-		// first, try to get an existing one called Attendance and return ID
-		// and if it isn't there, go ahead and create one and return the ID
-		$ch = curl_init();
+    function get_canvas_attendance_column_id($course_id) {
+        // first, try to get an existing one called Attendance and return ID
+        // and if it isn't there, go ahead and create one and return the ID
+        $ch = curl_init();
     $baseUrl = getPortalBaseUrl();
     $url = $baseUrl . '/api/v1/courses/'.$course_id.'/custom_gradebook_columns?access_token='.urlencode(CANVAS_TOKEN);
 
-		curl_setopt($ch, CURLOPT_URL, $url);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-		$answer = curl_exec($ch);
-		curl_close($ch);
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        $answer = curl_exec($ch);
+        curl_close($ch);
 
-		$obj = json_decode($answer, true);
-		foreach($obj as $item) {
-			if($item["title"] == "Attendance")
-				return $item["id"];
-		}
+        $obj = json_decode($answer, true);
+        foreach($obj as $item) {
+            if($item["title"] == "Attendance")
+                return $item["id"];
+        }
 
-		// not there, create a column
+        // not there, create a column
 
-		$ch = curl_init();
+        $ch = curl_init();
     $baseUrl = getPortalBaseUrl();
     $url = $baseUrl . '/api/v1/courses/'.$course_id.'/custom_gradebook_columns';
 
-		curl_setopt($ch, CURLOPT_URL, $url);
-		curl_setopt($ch, CURLOPT_POST, 1);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-		curl_setopt($ch, CURLOPT_POSTFIELDS,
-			urlencode("column[title]")."=Attendance" .
-			'&'.urlencode("column[read_only]")."=true" .
-			'&access_token='.urlencode(CANVAS_TOKEN));
-		$answer = curl_exec($ch);
-		curl_close($ch);
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS,
+            urlencode("column[title]")."=Attendance" .
+            '&'.urlencode("column[read_only]")."=true" .
+            '&access_token='.urlencode(CANVAS_TOKEN));
+        $answer = curl_exec($ch);
+        curl_close($ch);
 
-		$obj = json_decode($answer, true);
+        $obj = json_decode($answer, true);
 
-		return $obj["id"];
-	}
+        return $obj["id"];
+    }
 
-	foreach($braven_courses as $course_id) {
+    foreach($braven_courses as $course_id) {
 
-                // Note: this is also painfully slow, but this script is only run once a week in the middle
-                // of the night from a cronjob on the Kits server, so for now it's fine.
-	        echo "  Calling: populate_times_from_canvas(course_id=".$course_id.")\n";
-                populate_times_from_canvas($course_id);
-		
-	        echo "  Calling: get_cohorts_info(course_id=".$course_id.")\n";
-                $cohort_info = get_cohorts_info($course_id);
-        
-		$column_number = get_canvas_attendance_column_id($course_id);
+        // Note: this is also painfully slow, but this script is only run once a week in the middle
+        // of the night from a cronjob on the Kits server, so for now it's fine.
+        echo "###  Calling: populate_times_from_canvas(course_id=".$course_id.")\n";
+        populate_times_from_canvas($course_id);
 
-	        echo "  Loading attendance data to send for course_id=".$course_id.")\n";
-		$result = get_attendance_api_result($course_id, $cohort_info["students"]);
+        echo "###  Calling: get_cohorts_info(course_id=".$course_id.")\n";
+        $cohort_info = get_cohorts_info($course_id);
+
+        $column_number = get_canvas_attendance_column_id($course_id);
+
+        echo "###  Loading attendance data to send for course_id=".$course_id.")\n";
+        $result = get_attendance_api_result($course_id, $cohort_info["students"]);
 
 
-                // TODO: this is brutally slow since it loops over all students in all active courses and updates the value through the API one at a time.
-                // Either figure out how to set the values in bulk or maybe check timestamps of last time 
-                // data was sent (or query canvas for last time value was updated on the canvas end)
-                // vs last time attendance status was updated and only send new ones.
-                // Or maybe just pull all attendance data from canvas in one go per course, then only send updates for changed values.
-		foreach($result["statuses"] as $uid => $status) {
-                        $attendance_data = $status["total_present"] . "/". $status["total_events"];
-	                echo "  Calling set_canvas_attendance_info(course_id=" . $course_id . ", uid=" . $uid . ", attendance=". $attendance_data .")\n";
-			set_canvas_attendance_info($course_id, $column_number, $uid, $attendance_data);
-		}
-	}
+        // TODO: this is brutally slow since it loops over all students in all active courses and updates the value through the API one at a time.
+        // Either figure out how to set the values in bulk or maybe check timestamps of last time 
+        // data was sent (or query canvas for last time value was updated on the canvas end)
+        // vs last time attendance status was updated and only send new ones.
+        // Or maybe just pull all attendance data from canvas in one go per course, then only send updates for changed values.
+        foreach($result["statuses"] as $uid => $status) {
+            $attendance_data = $status["total_present"] . "/". $status["total_events"];
+            echo "  Calling set_canvas_attendance_info(course_id=" . $course_id . ", uid=" . $uid . ", attendance=". $attendance_data .")\n";
+            set_canvas_attendance_info($course_id, $column_number, $uid, $attendance_data);
+        }
+    }
 } else {
-	// if calling via web, we do an access token chck
+    // if calling via web, we do an access token chck
 
-	if(!isset($_REQUEST["access_token"]) || $_REQUEST["access_token"] != ATTENDANCE_API_KEY) {
-		die("Unauthorized");
-	}
+    if(!isset($_REQUEST["access_token"]) || $_REQUEST["access_token"] != ATTENDANCE_API_KEY) {
+        die("Unauthorized");
+    }
 
-	// given a list of student user ids and a course...
+    // given a list of student user ids and a course...
 
-	$course_id = (int) $_REQUEST["course_id"];
-	$users = array();
-	foreach($_REQUEST["user_id"] as $uid)
-		$users[] = array("id" => (int) $uid);
+    $course_id = (int) $_REQUEST["course_id"];
+    $users = array();
+    foreach($_REQUEST["user_id"] as $uid)
+        $users[] = array("id" => (int) $uid);
 
-	$response = get_attendance_api_result($course_id, $users);
+    $response = get_attendance_api_result($course_id, $users);
 
-	header("Content-Type: application/json; charset=utf-8");
+    header("Content-Type: application/json; charset=utf-8");
 
-	echo json_encode($response);
+    echo json_encode($response);
 }

--- a/attendance_shared.php
+++ b/attendance_shared.php
@@ -3,125 +3,204 @@ require_once("wp-config.php");
 require_once("courses.php");
 
 function get_lc_excused_status($event_id, $lc_email) {
-	global $pdo;
+    global $pdo;
 
-	$statement = $pdo->prepare("
-		SELECT
-			substitute_name, substitute_email, substitute_phone
-		FROM
-			attendance_lc_absences
-		WHERE
-			event_id = ?
-			AND
-			lc_email = ?
-	");
+    $statement = $pdo->prepare("
+        SELECT
+            substitute_name, substitute_email, substitute_phone
+        FROM
+            attendance_lc_absences
+        WHERE
+            event_id = ?
+            AND
+            lc_email = ?
+    ");
 
-	$statement->execute(array($event_id, $lc_email));
-	while($row = $statement->fetch(PDO::FETCH_ASSOC)) {
-		$row["excused"] = true;
-		return $row;
-	}
+    $statement->execute(array($event_id, $lc_email));
+    while($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+        $row["excused"] = true;
+        return $row;
+    }
 
-	return array("excused" => false);
+    return array("excused" => false);
 }
 
+// Parses the value of following header into an array of key/value pairs where 
+// the key is the page and the value is the link for that page.
+// Link: <http://someurl>; rel="current",<http://someurl>; rel="next",<http://someurl>; rel="prev",<http://someurl>; rel="first",<http://someurl>; rel="last"
+// Note: current, first, and last are guaranteed to be there. 
+// next or prev could be missing (if we just requested the first or last or there was only one).
+function parse_link_header($link_header_value){
+    $links = array();
+    $link_infos = explode(',', $link_header_value);
+    foreach ($link_infos as $link_info){
+        $link_info = explode(';', $link_info);
+        $matches = array();
+        preg_match('/rel="(.+?)"/', trim($link_info[1]), $matches);
+        if(count($matches) == 2){
+            $value = trim($link_info[0], ' <>'); // Trim space, <, and > from the beg and end. The format is: "<html://blah>
+            $links[$matches[1]] =  $value; 
+        }
+    }
+    return $links;
+}
 
 function get_canvas_events($course_id, $start_date, $end_date) {
-	$additional = "";
-	if($start_date !== null)
-		$additional .= "&start_date=".urlencode($start_date);
-	if($end_date !== null)
-		$additional .= "&end_date=".urlencode($end_date);
+    $additional = "";
+    if ($start_date === null && $end_date === null){
+        $additional .= "&all_events=1";
+    }
+    else {
+        if($start_date !== null)
+            $additional .= "&start_date=".urlencode($start_date);
+        if($end_date !== null)
+            $additional .= "&end_date=".urlencode($end_date);
+    }
+    $baseUrl = getPortalBaseUrl();
+    $url = $baseUrl . '/api/v1/calendar_events?per_page=500&context_codes[]=course_' . (urlencode($course_id)) . $additional . '&access_token=' . urlencode(CANVAS_TOKEN);
+    //echo "### Begin: get_canvas_events(course_id = $course_id) URL = $url \n";
+    $events = array();
+    get_canvas_events_with_pagination($url, $events);
+    return $events;
+}
 
-	$ch = curl_init();
-  $baseUrl = getPortalBaseUrl();
-  $url = $baseUrl . '/api/v1/calendar_events?per_page=500&context_codes[]=course_'.(urlencode($course_id)). '&access_token=' . urlencode(CANVAS_TOKEN) . $additional;
-	curl_setopt($ch, CURLOPT_URL, $url);
-	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-	$answer = curl_exec($ch);
-	curl_close($ch);
+// Recursive function to add the events JSON for the given URL
+// to the $events array. Returns the URL of the next page to 
+// get more events or NULL if there is no next page.
+function get_canvas_events_with_pagination($url, &$events) {
+    if (is_null($url)) {
+        return NULL;
+    }
+    else {
+        $link_header_value = NULL;
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
-	//print_r($answer);
+        // this function is called by curl for each header received
+        // It looks for the "Link: <value>" header and stores it in $link_header_value if found.
+        curl_setopt($ch, CURLOPT_HEADERFUNCTION,
+            function($curl, $header) use (&$link_header_value) {
+                $len = strlen($header);
+                if (is_null($link_header_value)) { // Once we find it, stop looking
+                    $header = explode(':', $header, 2);
+                    if (count($header) == 2 && strtolower(trim($header[0])) == 'link') {
+                        $link_header_value = trim($header[1]);
+                    }
+                }
+                return $len;
+            }
+        );
+        $answer = curl_exec($ch);
+        curl_close($ch);
 
-	// trim off any cross-site get padding, if present,
-	// keeping just the json object
-	$answer = substr($answer, strpos($answer, "["));
-	$obj = json_decode($answer, true);
+        $links = parse_link_header($link_header_value);
+        //echo "### get_canvas_events_with_pagination(): parsed links array = ".print_r($links, true)."\n";
 
-	return $obj;
+        // trim off any cross-site get padding, if present,
+        // keeping just the json object
+        $answer = substr($answer, strpos($answer, "["));
+        $obj = json_decode($answer, true);
+        if (count($obj) > 0){
+            //echo "### get_canvas_events_with_pagination(): Adding new events (count = ".count($obj).") onto the existing array of events (count = ".count($events).")\n";
+            $events = array_merge($events, $obj);
+        }
+
+        // Get the value of "page=X" out of the current and last URLs in the Link header.
+        // We're done if we just processed the last one.
+        $current_matches = array();
+        preg_match('/page=(\d+)/', $links['current'], $current_matches);
+        $current_page = $current_matches[1];
+        $last_matches = array();
+        preg_match('/page=(\d+)/', $links['last'], $last_matches);
+        $last_page = $last_matches[1];
+        if ($current_page == $last_page) {
+            return NULL;
+        }
+        else {
+            $next_url = $links['next'] . '&access_token=' . urlencode(CANVAS_TOKEN);
+            return get_canvas_events_with_pagination($next_url, $events);
+        }
+    }
 }
 
 function get_canvas_learning_labs($course_id, $start_date = null, $end_date = null) {
-	$list = array();
-	$events = get_canvas_events($course_id, $start_date, $end_date);
-	foreach($events as $event) {
-		$title = $event["title"];
-		// the format here is "Learning Lab #: NAME (Cohort)"
-		// so gonna kinda fake-parse this. so hacky lololol
+    $list = array();
+    $events = get_canvas_events($course_id, $start_date, $end_date);
+    echo "### Processing " . count($events) . " events, looking for LLs\n";
+    foreach($events as $event) {
+        $title = $event["title"];
+        // the format here is "Learning Lab #: NAME (Cohort)"
+        // so gonna kinda fake-parse this. so hacky lololol
 
-		$matches = array();
-		preg_match('/[^:]+: ([^\(]+)\((.*)\)/', $title, $matches);
+        $matches = array();
+        preg_match('/[^:]+: ([^\(]+)\((.*)\)/', $title, $matches);
 
-		if(count($matches) < 2)
-			continue; // not actually one of these events
+        if(count($matches) < 2){
+            //echo "### get_canvas_learning_labs(): $title is NOT a Learning Lab event -- skipping";
+            continue; // not actually one of these events
+        } else {
+            //echo "### get_canvas_learning_labs(): $title IS a Learning Lab even -- putting it in the list.";
+        }
 
-		$event_name = trim($matches[1]);
-		$cohort = trim($matches[2]);
-		$list[] = array("event" => $event_name, "cohort" => $cohort, "end_at" => $event["end_at"]);
-	}
 
-	return $list;
+        $event_name = trim($matches[1]);
+        $cohort = trim($matches[2]);
+        $list[] = array("event" => $event_name, "cohort" => $cohort, "end_at" => $event["end_at"]);
+    }
+
+    return $list;
 }
 
 function populate_times_from_canvas($course_id) {
-	// just want all times ever
-	$list = get_canvas_learning_labs($course_id, '2000-01-01', '2300-12-31');
-	foreach($list as $data) {
-		global $pdo;
+    $list = get_canvas_learning_labs($course_id);
+    echo "Setting Learning Lab event times for ". count($list) ." sections found in the Portal Calendar.\n";
+    foreach($list as $data) {
+        global $pdo;
 
-		// translate to mysql format
-		$data["end_at"] = str_replace("T", " ", str_replace("Z", "", $data["end_at"])); 
+        // translate to mysql format
+        $data["end_at"] = str_replace("T", " ", str_replace("Z", "", $data["end_at"])); 
 
-                // TODO: there is a bug here. This result of get_canvas_learning_labs()
-                // is every individual cohort (aka section) and the LL event time for that cohort. 
-                // But we completely ignore that in the local attendance_events database. 
-                // All cohorts are set null and the event_time for the overall LL is set to the last
-                // cohort datetime that happens to be in the list which could be incorrect for some cohorts. 
-                //
-                // The auto-nag feature directly queries the Portal when deciding the event_time, 
-                // so this doesn't currently impact that feature but if we try to optimize it by looking at
-                // the local database for times instead of hitting the Portal hourly to get them it wouldn't work properly.
-                //
-                // The other feature which relies on this is the one which pushes attendance data to the Portal 
-                // to show up in the gradebook. So say that an LL was on Tues/Thurs
-                // and the event_time for the overall LL was set to Tues in attendance_events. If we ran this on a 
-                // Wed, the gradebook would show correctly for the Tues cohorts, but the Thurs ones haven't happened yet
-                // but we think they did, so the gradebook would should that they were present for one less than the total
-                // LLs that have happened (and the total is wrong). 
-                //
-                // Fortunately, this bug is currently masked by that fact that we only run this in the middle of the night
-                // on Sunday. Dear me. I'm leaving this comment here for the day that we try to optimize this stuff and update
-                // the gradebook more frequently and all sorts of weirdness happens b/c of this... 
+        // TODO: there is a bug here. This result of get_canvas_learning_labs()
+        // is every individual cohort (aka section) and the LL event time for that cohort. 
+        // But we completely ignore that in the local attendance_events database. 
+        // All cohorts are set null and the event_time for the overall LL is set to the last
+        // cohort datetime that happens to be in the list which could be incorrect for some cohorts. 
+        //
+        // The auto-nag feature directly queries the Portal when deciding the event_time, 
+        // so this doesn't currently impact that feature but if we try to optimize it by looking at
+        // the local database for times instead of hitting the Portal hourly to get them it wouldn't work properly.
+        //
+        // The other feature which relies on this is the one which pushes attendance data to the Portal 
+        // to show up in the gradebook. So say that an LL was on Tues/Thurs
+        // and the event_time for the overall LL was set to Tues in attendance_events. If we ran this on a 
+        // Wed, the gradebook would show correctly for the Tues cohorts, but the Thurs ones haven't happened yet
+        // but we think they did, so the gradebook would should that they were present for one less than the total
+        // LLs that have happened (and the total is wrong). 
+        //
+        // Fortunately, this bug is currently masked by that fact that we only run this in the middle of the night
+        // on Sunday. Dear me. I'm leaving this comment here for the day that we try to optimize this stuff and update
+        // the gradebook more frequently and all sorts of weirdness happens b/c of this... 
 
-		// echo "{$data["end_at"]} $course_id / {$data["event"]}\n";
+        // echo "{$data["end_at"]} $course_id / {$data["event"]}\n";
 
-		$statement = $pdo->prepare("
-			UPDATE
-				attendance_events
-			SET
-				event_time = ?
-			WHERE
-				course_id = ?
-				AND
-				name = ?
-		");
+        $statement = $pdo->prepare("
+                UPDATE
+                attendance_events
+                SET
+                event_time = ?
+                WHERE
+                course_id = ?
+                AND
+                name = ?
+                ");
 
-		$statement->execute(array(
-			$data["end_at"],
-			$course_id,
-			$data["event"]
-		));
-	}
+        $statement->execute(array(
+                    $data["end_at"],
+                    $course_id,
+                    $data["event"]
+                    ));
+    }
 }
 
 // Note: originally the check for which protocol to use was the following:
@@ -160,204 +239,204 @@ function getSSOBaseUrl() {
 }
 
 function isTa($user_email, $cohort_info) {
-	return in_array(strtolower($user_email), $cohort_info["tas"]);
+    return in_array(strtolower($user_email), $cohort_info["tas"]);
 }
 
 function get_cohorts_info($course_id) {
-	if(isset($_SESSION["cohort_course_info_$course_id"]))
-		return $_SESSION["cohort_course_info_$course_id"];
+    if(isset($_SESSION["cohort_course_info_$course_id"]))
+        return $_SESSION["cohort_course_info_$course_id"];
 
-	$ch = curl_init();
+    $ch = curl_init();
   $baseUrl = getPortalBaseUrl();
-	$url = $baseUrl . '/bz/course_cohort_information?course_ids[]='.((int) $course_id). '&access_token=' . urlencode(CANVAS_TOKEN);
+    $url = $baseUrl . '/bz/course_cohort_information?course_ids[]='.((int) $course_id). '&access_token=' . urlencode(CANVAS_TOKEN);
 
   // Uncomment to log above call to browswer console so you can login to server and try to curl it to see what you get.
   // Note: curl has to be run like: curl --globoff -vvv "http://canvasweb:3000/bz/course_cohort_information?course_ids[]=71&access_token=<yourtoken>"
   //echo("<script>console.log('Attendance tracker calling the following to get attendance cohort info from Canvas: " . $url . "');</script>");
 
-	curl_setopt($ch, CURLOPT_URL, $url);
-	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-	$answer = curl_exec($ch);
-	curl_close($ch);
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    $answer = curl_exec($ch);
+    curl_close($ch);
 
 
-	// trim off any cross-site get padding, if present,
-	// keeping just the json object
-	$answer = substr($answer, strpos($answer, "{"));
-	$obj = json_decode($answer, TRUE);
+    // trim off any cross-site get padding, if present,
+    // keeping just the json object
+    $answer = substr($answer, strpos($answer, "{"));
+    $obj = json_decode($answer, TRUE);
 
-	$sections = $obj["courses"][0]["sections"];
-	$lcs = array();
-	$students = array();
-	$tas = array();
-	foreach($sections as $section) {
-		foreach($section["enrollments"] as $enrollment) {
-			if($enrollment["type"] == "TaEnrollment")
-				$lcs[] = $enrollment;
-			if($enrollment["type"] == "StudentEnrollment")
-				$students[] = $enrollment;
-		}
-		if(isset($section["ta_email"]))
-			$tas[] = strtolower($section["ta_email"]);
-	}
+    $sections = $obj["courses"][0]["sections"];
+    $lcs = array();
+    $students = array();
+    $tas = array();
+    foreach($sections as $section) {
+        foreach($section["enrollments"] as $enrollment) {
+            if($enrollment["type"] == "TaEnrollment")
+                $lcs[] = $enrollment;
+            if($enrollment["type"] == "StudentEnrollment")
+                $students[] = $enrollment;
+        }
+        if(isset($section["ta_email"]))
+            $tas[] = strtolower($section["ta_email"]);
+    }
 
-	return $_SESSION["cohort_course_info_$course_id"] = array(
-		"lcs" => $lcs,
-		"tas" => $tas,
-		"students" => $students,
-		"sections" => $sections
-	);
+    return $_SESSION["cohort_course_info_$course_id"] = array(
+        "lcs" => $lcs,
+        "tas" => $tas,
+        "students" => $students,
+        "sections" => $sections
+    );
 }
 
 function log_nag($event_id, $lc_email, $answer) {
-	global $pdo;
+    global $pdo;
 
-	$statement = $pdo->prepare("
-		INSERT INTO
-			attendance_nag_log
-			(event_id, date_sent, lc_email, raw_response)
-		VALUES
-			(?, NOW(), ?, ?)
-	");
-	$statement->execute(array($event_id, $lc_email, $answer));
+    $statement = $pdo->prepare("
+        INSERT INTO
+            attendance_nag_log
+            (event_id, date_sent, lc_email, raw_response)
+        VALUES
+            (?, NOW(), ?, ?)
+    ");
+    $statement->execute(array($event_id, $lc_email, $answer));
 }
 
 function get_nag_info($lc_email) {
-	global $pdo;
+    global $pdo;
 
-	$statement = $pdo->prepare("
-		SELECT
-			count(id) AS count,
-			max(date_sent) AS last,
-			DATE_ADD(max(date_sent),INTERVAL 7 DAY) > NOW() AS recent
-		FROM
-			attendance_nag_log
-		WHERE
-			lc_email = ?
-	");
+    $statement = $pdo->prepare("
+        SELECT
+            count(id) AS count,
+            max(date_sent) AS last,
+            DATE_ADD(max(date_sent),INTERVAL 7 DAY) > NOW() AS recent
+        FROM
+            attendance_nag_log
+        WHERE
+            lc_email = ?
+    ");
 
-	$statement->execute(array($lc_email));
-	return $statement->fetch();
+    $statement->execute(array($lc_email));
+    return $statement->fetch();
 }
 
 function load_student_status($event_id, $students_info) {
-	if(count($students_info) == 0)
-		return array();
+    if(count($students_info) == 0)
+        return array();
 
-	global $pdo;
+    global $pdo;
 
-	$students = array();
-	foreach($students_info as $student)
-		$students[] = $student["id"];
+    $students = array();
+    foreach($students_info as $student)
+        $students[] = $student["id"];
 
-	$statement = $pdo->prepare("
-		SELECT
-			person_id, present, reason
-		FROM
-			attendance_people
-		WHERE
-			event_id = ?
-			AND
-			person_id IN  (".str_repeat('?,', count($students) - 1)."?)
+    $statement = $pdo->prepare("
+        SELECT
+            person_id, present, reason
+        FROM
+            attendance_people
+        WHERE
+            event_id = ?
+            AND
+            person_id IN  (".str_repeat('?,', count($students) - 1)."?)
 
-	");
+    ");
 
-	$args = array($event_id);
-	$args = array_merge($args, $students);
+    $args = array($event_id);
+    $args = array_merge($args, $students);
 
-	$reasons = array();
-	$result = array();
-	$original_result = array();
+    $reasons = array();
+    $result = array();
+    $original_result = array();
 
-	foreach($students as $student) {
-		$result[$student] = "null";
-		$original_result[$student] = "null";
-	}
+    foreach($students as $student) {
+        $result[$student] = "null";
+        $original_result[$student] = "null";
+    }
 
-	$statement->execute($args);
-	while($row = $statement->fetch(PDO::FETCH_ASSOC)) {
-		// format it as a bool string here so we don't have to get ambiguity later with override strings
-		$value = "null";
-		if($row["present"] !== null)
-		switch($row["present"]) {
-			case 0:
-				$value = "false";
-			break;
-			case 1:
-				$value = "true";
-			break;
-			case 2:
-				$value = "late";
-			break;
-		}
-		$result[$row["person_id"]] = $value;
-		$original_result[$row["person_id"]] = $value;
-		$reasons[$row["person_id"]] = $row["reason"];
-	}
+    $statement->execute($args);
+    while($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+        // format it as a bool string here so we don't have to get ambiguity later with override strings
+        $value = "null";
+        if($row["present"] !== null)
+        switch($row["present"]) {
+            case 0:
+                $value = "false";
+            break;
+            case 1:
+                $value = "true";
+            break;
+            case 2:
+                $value = "late";
+            break;
+        }
+        $result[$row["person_id"]] = $value;
+        $original_result[$row["person_id"]] = $value;
+        $reasons[$row["person_id"]] = $row["reason"];
+    }
 
-	// and now we need to load overrides for withdrawn students, etc.
+    // and now we need to load overrides for withdrawn students, etc.
 
-	$statement = $pdo->prepare("
-		SELECT
-			person_id,
-			status
-		FROM
-			attendance_people_statuses
-		WHERE
-			course_id = (SELECT course_id FROM attendance_events WHERE id = ?)
-			AND
-			person_id IN  (".str_repeat('?,', count($students) - 1)."?)
-			AND
-			as_of < (SELECT event_time FROM attendance_events WHERE id = ?)
-		ORDER BY
-			as_of ASC -- the purpose here is to get the latest one last, so the loop below will defer to it. i really only want the max as_of that fits the othe requirements per person but idk how to express that in this version of mysql. meh.
-	");
+    $statement = $pdo->prepare("
+        SELECT
+            person_id,
+            status
+        FROM
+            attendance_people_statuses
+        WHERE
+            course_id = (SELECT course_id FROM attendance_events WHERE id = ?)
+            AND
+            person_id IN  (".str_repeat('?,', count($students) - 1)."?)
+            AND
+            as_of < (SELECT event_time FROM attendance_events WHERE id = ?)
+        ORDER BY
+            as_of ASC -- the purpose here is to get the latest one last, so the loop below will defer to it. i really only want the max as_of that fits the othe requirements per person but idk how to express that in this version of mysql. meh.
+    ");
 
-	$args[] = $event_id; // same args as before except for one more event id reference
-	$statement->execute($args);
+    $args[] = $event_id; // same args as before except for one more event id reference
+    $statement->execute($args);
 
-	while($row = $statement->fetch(PDO::FETCH_ASSOC)) {
-		if(strlen($row["status"]) > 0) {
-			$result[$row["person_id"]] = $row["status"];
-		} else {
-			// if the override is blank, it means it was undone since now
-			$result[$row["person_id"]] = $original_result[$row["person_id"]];
-		}
-	}
+    while($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+        if(strlen($row["status"]) > 0) {
+            $result[$row["person_id"]] = $row["status"];
+        } else {
+            // if the override is blank, it means it was undone since now
+            $result[$row["person_id"]] = $original_result[$row["person_id"]];
+        }
+    }
 
-	return array(
-		"reasons" => $reasons,
-		"result" => $result
-	);
+    return array(
+        "reasons" => $reasons,
+        "result" => $result
+    );
 }
 
 function get_all_events($course_id) {
-	global $pdo;
+    global $pdo;
 
-	$statement = $pdo->prepare("
-		SELECT
-			id, name, event_time, course_id
-		FROM
-			attendance_events
-		WHERE
-			course_id = ?
-		ORDER BY
-			display_order, event_time
-	");
+    $statement = $pdo->prepare("
+        SELECT
+            id, name, event_time, course_id
+        FROM
+            attendance_events
+        WHERE
+            course_id = ?
+        ORDER BY
+            display_order, event_time
+    ");
 
-	$result = array();
-	$statement->execute(array($course_id));
-	while($row = $statement->fetch(PDO::FETCH_ASSOC)) {
-		$result[] = $row;
-	}
+    $result = array();
+    $statement->execute(array($course_id));
+    while($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+        $result[] = $row;
+    }
 
-	return $result;
+    return $result;
 }
 
 $pdo_opt = [
-	PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-	PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-	PDO::ATTR_EMULATE_PREPARES   => false,
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
 ];
 
 $pdo = new PDO("mysql:host=" . DB_HOST . ";dbname=" . DB_ATTENDANCE_NAME . ";charset=utf8mb4", DB_USER, DB_PASSWORD, $pdo_opt);


### PR DESCRIPTION
The code was written to handle up to 500 sections with dates set
for their Learning Labs per course. There can be more than 500 sections
though. This came about b/c there is something weird going on which only
happens in production, where the call to <portal>/api/v1/calendar_events was only
returning 50 results per call. Now, the API call handles pagination so
no matter how many results are returned per call, it will page through them
all. So this should work in production even with that weird behavior (which
I still want to get to the bottom of).

NOTE: this still may not work for Braven X. I think it's b/c the sections are named with characters that are URL escaped causing the regex to not recognize them as LLs.

TESTING
- Did a dev refresh of kits and canvas from prod.
- Hacked the lib/api.rb file in the Portal code to set a universal max of
  50 results for an api call in the self.max_per_page property.
- Ran: cd /var/www/html; php attendance_api.php
- Verified that Learning Lab event times were properly populated locally in the DB.
- Verified that attendance data was sent to the Portal gradebook with the proper
  total attendance events (those in the past) count.

-----
**When reviewing this PR, ignore whitespace!** 
![image](https://user-images.githubusercontent.com/5596986/66706759-dd4d6600-ed04-11e9-8e5c-02bd2a5fdcc2.png)