### PR TITLE
Update dev DB refresh to use new nightly snapshot.

### DIFF
--- a/docker-compose/scripts/contentrefresh.sh
+++ b/docker-compose/scripts/contentrefresh.sh
@@ -1,26 +1,17 @@
 #!/bin/bash
 
-echo "Refreshing uploads content from kits-dev-files S3 bucket"
+echo "Refreshing wp-content from latest production snapshot"
 if aws --version 2> /dev/null; then
 
   # Note: not using gzip b/c this is additive and once you have the baseline set of uploads, then each subsequent
   # run just syncs to changes
-  aws s3 sync 's3://kits-dev-files/uploads/' './wp-content/uploads/'
-  if [ $? -ne 0 ]
-  then
-    echo "Failed pulling uploads folder from kits-dev-files S3 bucket using:"
-    exit 1;
-  fi
+  aws s3 sync 's3://kits-staging-wp-content/uploads/' './wp-content/uploads/' \
+    || { echo >&2 "Error: Failed pulling uploads folder from kits-staging-wp-content S3 bucket"; exit 1; }
 
-  aws s3 sync 's3://kits-dev-files/plugins/' './wp-content/plugins/'
-  if [ $? -ne 0 ]
-  then
-    echo "Failed pulling plugins folder from kits-dev-files S3 bucket using:"
-    exit 1;
-  fi
+  aws s3 sync 's3://kits-staging-wp-content/plugins/' './wp-content/plugins/' \
+    || { echo >&2 "Error: Failed pulling plugins folder from kits-staging-wp-content S3 bucket"; exit 1; }
 
 else
-  # Install AWS CLI if it's not there
   echo "Error: Please install 'aws'. E.g."
   echo "   $ pip3 install awscli"
   echo ""


### PR DESCRIPTION
The nightly snapshots stored are staging databases. This commit
just changes the dbrefresh.sh script to load from that.

TESTING:
- Ran dbrefresh.sh, verified that the script was pulling from the new S3
  bucket.
- Logged into http://kitsweb and checked that some attendance records
  were updated that existing in prod but not my staging copy
- Did a local mysqldump and grepped for kitsweb to make sure the URLs where updated.